### PR TITLE
feat: support max thinking level

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ A minimal agent — just `name` and `description` — gets everything: all tools
 | `skills` | `true` \| `string[]` \| `false` | `true` | **Skill whitelist** — which skills are available (metadata in system prompt). |
 | `preload_skills` | `string[]` \| `false` | `false` | **Full skill injection** — dump complete SKILL.md content into the system prompt instead of metadata-only. |
 | `model` | string | inherit parent | Default model as `"provider/model-id"`. See [Model Resolution](#model-resolution). |
-| `thinking` | string | inherit parent | One of: `off`, `minimal`, `low`, `medium`, `high`, `xhigh`. |
+| `thinking` | string | inherit parent | One of: `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`. |
 | `max_turns` | number | unlimited | Soft turn limit. Agent gets a steer at the limit, then `max_turns + graceTurns` before hard abort. |
 | `max_tokens` | number | unlimited | Max output tokens per LLM response. Injected into provider request payloads. |
 | `hidden` | `true` \| `false` | `false` | `true` hides the type from the enum (LLM can't see or invoke it). Still callable by name. |

--- a/src/agents/agent-runner.ts
+++ b/src/agents/agent-runner.ts
@@ -402,7 +402,10 @@ async function initSession(
     modelRegistry: ctx.modelRegistry, model,
     tools: getToolNamesForType(type), resourceLoader: loader,
   };
-  if (thinkingLevel) sessionOpts.thinkingLevel = thinkingLevel;
+  if (thinkingLevel) {
+    // pi-coding-agent < 0.80.6 does not include "max" in its ThinkingLevel type.
+    sessionOpts.thinkingLevel = thinkingLevel as typeof sessionOpts.thinkingLevel;
+  }
   const result = await createAgentSession(sessionOpts);
 
   // Inject max_tokens into provider request payloads.

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ import type { LifetimeUsage, AgentUsage } from "./agents/usage.js";
 import type { SubagentType, AgentInvocation } from "./agents/types.js";
 
 /** Thinking level for agent models. */
-export type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+export type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 
 /** Tool activity event: start/end of a tool invocation. */
 export interface ToolActivity {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,7 +43,7 @@ export function safeReadFile(filePath: string): string | undefined {
 
 /** All valid thinking levels. */
 export const VALID_THINKING_LEVELS: readonly ThinkingLevel[] = [
-  "off", "minimal", "low", "medium", "high", "xhigh",
+  "off", "minimal", "low", "medium", "high", "xhigh", "max",
 ] as const;
 
 /**

--- a/test/agents/agent-discovery.test.ts
+++ b/test/agents/agent-discovery.test.ts
@@ -96,7 +96,7 @@ model: anthropic/claude-haiku-4-5-20251001
 tools: read, bash, grep
 extensions: none
 skills: all
-thinking: high
+thinking: max
 max_turns: "50"
 max_tokens: "2048"
 hidden: "false"
@@ -112,7 +112,7 @@ This is the system prompt body.
     expect(result.tools).toEqual(["read", "bash", "grep"]);
     expect(result.extensions).toBe(false); // "none" → false
     expect(result.skills).toBe(true); // "all" → true
-    expect(result.thinking).toBe("high");
+    expect(result.thinking).toBe("max");
     expect(result.max_turns).toBe(50);
     expect(result.max_tokens).toBe(2048);
     expect(result.hidden).toBe(false);


### PR DESCRIPTION
## Summary

Pi now supports a `max` thinking level. This PR adds it to pi-subagents-lite's local thinking-level type and validation list, which also makes it available in the spawn UI and agent frontmatter.

The assignment into `createAgentSession` uses a narrow compatibility cast because older `pi-coding-agent` type definitions do not yet include `max`, while the runtime option remains a string-based thinking level.

## Changes

- accept `thinking: max` in agent frontmatter and tool inputs
- expose `max` in the spawn wizard's thinking-level options
- document the new level in the README
- cover `max` frontmatter parsing in tests

## Verification

- `bun run typecheck`
- `bun run test` — 42 files, 837 tests passed
