### PR TITLE
Improve agent metadata, usage statistics, and widget presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ Running agents appear in the live widget:
 
 ```
 ◈ Agents
-├─ ⠙ Agent  Write model precedence unit tests  6⚙︎  3⟳  ↑6.8k ↓1.3k 6.0%/128k (auto)  12s
+├─ ⠙ Agent  Write model precedence unit tests  6⚙︎  3⟳ · ↑6.8k ↓1.3k 6.0%/128k (auto) · 12s
 │  │ tail -f /tmp/pi-agent-outputs/bb3382a9-1f7e-474.log
 │  └ The file already exists but is ~175 lines. The user wants a …
-├─ ⠙ Agent  Code review of agent-runner.ts  4⚙︎  2⟳  ↑7.2k ↓1.5k 4.0%/128k (auto)  12s
+├─ ⠙ Agent  Code review of agent-runner.ts  4⚙︎  2⟳ · ↑7.2k ↓1.5k 4.0%/128k (auto) · 12s
 │  └ Now let me check the types and related files for context on …
-└─ ⠙ Explore  Explore codebase architecture  13⚙︎  4⟳  ↑16k ↓2.9k 15.0%/128k (auto)  12s
+└─ ⠙ Explore  Explore codebase architecture  13⚙︎  4⟳ · ↑16k ↓2.9k 15.0%/128k (auto) · 12s
    └ ## Architecture Summary: pi-subagents-lite
 ```
 
@@ -68,7 +68,7 @@ Background agents deliver a result notification when done:
 ```
  Subagent Result
 
- ✓ Explore (model-name)·13⚙︎ ·5⟳ ·↑25.9k↓4.9k 15%·21s
+ ✓ Explore (model-name) · 13⚙︎  5⟳ · ↑25.9k ↓4.9k 15% · 21s
    Explore codebase architecture
    tail -f /tmp/pi-agent-outputs/4f6b0f08-7a9a-419.log
 ```
@@ -77,7 +77,7 @@ Foreground results land inline:
 
 ```
  ▸ Explore
- ✓ 31⚙︎ ·6⟳ ·↑48.1k↓9.2k 28%·39s
+ ✓ 31⚙︎  6⟳ · ↑48.1k ↓9.2k 28% · 39s
    Explore project directory structure
 ```
 
@@ -85,7 +85,7 @@ Stop a running agent from `/agents`:
 
 ```
 ○ Agents
-└─ ■ Agent  Code review of agent-runner.ts  12⚙︎ ·10⟳ ·↑32.8k↓6.2k 8%·52s stopped
+└─ ■ Agent  Code review of agent-runner.ts  12⚙︎  10⟳ · ↑32.8k ↓6.2k 8% · 52s stopped
     tail -f /tmp/pi-agent-outputs/23689696-3cd3-400.log
 ```
 
@@ -261,14 +261,14 @@ Persistent bar above the editor showing running and completed agents, updating l
 
 **Full mode** (tree, header + `tail -f` path + activity):
 ```
-├─ ⠙ Explore  description  3⚙︎  5≤30⟳  ↑10k ↓1.8k R85k W3.0k CH89.2% $0.024 45.0%/128k (auto)  1h 2m 3s
+├─ ⠙ Explore  description  3⚙︎  5≤30⟳ · ↑10k ↓1.8k R85k W3.0k CH89.2% $0.024 45.0%/128k (auto) · 1h 2m 3s
 │  │ tail -f /tmp/pi-agent-outputs/...
 │  └ thinking…
 ```
 
 **Compact mode** (single line, description truncated, activity inline):
 ```
-├─ ⠙ Explore  description trunc…  3⚙︎  5≤30⟳  ↑10k ↓1.8k R85k W3.0k CH89.2% $0.024 45.0%/128k (auto)  1h 2m 3s  thinking…
+├─ ⠙ Explore  description trunc…  3⚙︎  5≤30⟳ · ↑10k ↓1.8k R85k W3.0k CH89.2% $0.024 45.0%/128k (auto) · 1h 2m 3s  thinking…
 ```
 
 Turn format uses `≤` and `⟳` (`5≤30⟳` = 5 of 30 turns). Turn count is colored by usage: normal < 80%, warning 80–99%, error at 100%. The max is hidden when well below the limit. The contiguous usage group follows Pi: `↑input ↓output Rcache-read Wcache-write CHhit-rate $cost context/window (auto)`. Input visibility also controls cache fields; output, context, and cost remain independently configurable.
@@ -281,7 +281,7 @@ Fullscreen transcript viewer for agent sessions — opens automatically from `/a
 
 **Navigation:** `↑↓` / `PgUp/PgDn` scroll · `g`/`G` top/bottom · `Home`/`End` jump · `f` fullscreen · `r` refresh · `q`/`Esc` close.
 
-**Stats line:** `15⟳  ↑12k ↓8.0k R85k W3.0k CH89.2% $0.024 47.0%/128k (auto)  47s`. The configured stats-visibility toggles also apply here, including **Cost display**. The same Pi-compatible usage group is used by foreground and background result cards.
+**Stats line:** `15⟳ · ↑12k ↓8.0k R85k W3.0k CH89.2% $0.024 47.0%/128k (auto) · 47s`. Tools and turns form one counter group with two spaces between them; Pi footer metrics remain contiguous, with ` · ` separating the counter, Pi, and duration groups. The configured stats-visibility toggles also apply here, including **Cost display**. The same Pi-compatible usage group is used by foreground and background result cards.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Fullscreen transcript viewer for agent sessions — opens automatically from `/a
 
 **Navigation:** `↑↓` / `PgUp/PgDn` scroll · `g`/`G` top/bottom · `Home`/`End` jump · `f` fullscreen · `r` refresh · `q`/`Esc` close.
 
-**Stats line:** `15⟳ · ↑12k ↓8.0k R85k W3.0k CH89.2% $0.024 47.0%/128k (auto) · 47s`. The configured stats-visibility toggles also apply here, including **Cost display**. The same Pi-compatible usage group is used by foreground and background result cards.
+**Stats line:** `15⟳  ↑12k ↓8.0k R85k W3.0k CH89.2% $0.024 47.0%/128k (auto)  47s`. The configured stats-visibility toggles also apply here, including **Cost display**. The same Pi-compatible usage group is used by foreground and background result cards.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ Running agents appear in the live widget:
 
 ```
 ◈ Agents
-├─ ⠙ Agent  Write model precedence unit tests  6🛠 ·3⟳ ·↑6.8k↓1.3k 6%·12s
+├─ ⠙ Agent  Write model precedence unit tests  6🛠 · 3⟳ · ↑6.8k ↓1.3k 6.0%/128k (auto) · 12s
 │  │ tail -f /tmp/pi-agent-outputs/bb3382a9-1f7e-474.log
 │  └ The file already exists but is ~175 lines. The user wants a …
-├─ ⠙ Agent  Code review of agent-runner.ts  4🛠 ·2⟳ ·↑7.2k↓1.5k 4%·12s
+├─ ⠙ Agent  Code review of agent-runner.ts  4🛠 · 2⟳ · ↑7.2k ↓1.5k 4.0%/128k (auto) · 12s
 │  └ Now let me check the types and related files for context on …
-└─ ⠙ Explore  Explore codebase architecture  13🛠 ·4⟳ ·↑16.1k↓2.9k 15%·12s
+└─ ⠙ Explore  Explore codebase architecture  13🛠 · 4⟳ · ↑16k ↓2.9k 15.0%/128k (auto) · 12s
    └ ## Architecture Summary: pi-subagents-lite
 ```
 
@@ -257,21 +257,21 @@ Management menu with four sections:
 
 ### Live widget
 
-Persistent bar above the editor showing running and completed agents, updating live. Running agents show a spinner, current tool activity, turn count, token usage (with optional context-fill %), and elapsed time. Completed agents show a check mark with final stats. Click the `tail -f` path to follow output logs.
+Persistent bar above the editor showing running and completed agents, updating live. Running agents show a spinner, current tool activity, turn count, Pi-compatible token/cache/cost usage, context window utilization, and elapsed time. Completed agents retain their final context and subscription snapshot. Click the `tail -f` path to follow output logs.
 
 **Full mode** (tree, header + `tail -f` path + activity):
 ```
-├─ ⠙ Explore  description  3🛠 ·5≤30⟳ ·↑10.2k↓1.8k 45%·1h 2m 3s
+├─ ⠙ Explore  description  3🛠 · 5≤30⟳ · ↑10k ↓1.8k R85k W3.0k CH89.2% $0.024 45.0%/128k (auto) · 1h 2m 3s
 │  │ tail -f /tmp/pi-agent-outputs/...
 │  └ thinking…
 ```
 
 **Compact mode** (single line, description truncated, activity inline):
 ```
-├─ ⠙ Explore  description trunc…  3🛠 ·5≤30⟳ ·↑10.2k↓1.8k 45%·1h 2m 3s  thinking…
+├─ ⠙ Explore  description trunc…  3🛠 · 5≤30⟳ · ↑10k ↓1.8k R85k W3.0k CH89.2% $0.024 45.0%/128k (auto) · 1h 2m 3s  thinking…
 ```
 
-Turn format uses `≤` and `⟳` (`5≤30⟳` = 5 of 30 turns). Turn count is colored by usage: normal < 80%, warning 80–99%, error at 100%. The max is hidden when well below the limit. Token glyphs (`↑` input, `↓` output) are self-explanatory — no "tokens" label.
+Turn format uses `≤` and `⟳` (`5≤30⟳` = 5 of 30 turns). Turn count is colored by usage: normal < 80%, warning 80–99%, error at 100%. The max is hidden when well below the limit. The contiguous usage group follows Pi: `↑input ↓output Rcache-read Wcache-write CHhit-rate $cost context/window (auto)`. Input visibility also controls cache fields; output, context, and cost remain independently configurable.
 
 Compact mode is active when **Force compact** is ON, or **ctrl+o shortcut** is ON and the user has collapsed tool expansion. Force compact always wins.
 
@@ -281,7 +281,7 @@ Fullscreen transcript viewer for agent sessions — opens automatically from `/a
 
 **Navigation:** `↑↓` / `PgUp/PgDn` scroll · `g`/`G` top/bottom · `Home`/`End` jump · `f` fullscreen · `r` refresh · `q`/`Esc` close.
 
-**Stats line:** `↑12.0k · ↓8.0k · W3.0k · $0.024 · 15 turns · 47s`. With **Cost display** ON, shows dollar cost. Toggle as a session override from Model settings.
+**Stats line:** `15⟳ · ↑12k ↓8.0k R85k W3.0k CH89.2% $0.024 47.0%/128k (auto) · 47s`. The same Pi-compatible usage group is used by foreground and background result cards; cost remains controlled by **Cost display**.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ Running agents appear in the live widget:
 
 ```
 ◈ Agents
-├─ ⠙ Agent  Write model precedence unit tests  6🛠 · 3⟳ · ↑6.8k ↓1.3k 6.0%/128k (auto) · 12s
+├─ ⠙ Agent  Write model precedence unit tests  6⚙︎ · 3⟳ · ↑6.8k ↓1.3k 6.0%/128k (auto) · 12s
 │  │ tail -f /tmp/pi-agent-outputs/bb3382a9-1f7e-474.log
 │  └ The file already exists but is ~175 lines. The user wants a …
-├─ ⠙ Agent  Code review of agent-runner.ts  4🛠 · 2⟳ · ↑7.2k ↓1.5k 4.0%/128k (auto) · 12s
+├─ ⠙ Agent  Code review of agent-runner.ts  4⚙︎ · 2⟳ · ↑7.2k ↓1.5k 4.0%/128k (auto) · 12s
 │  └ Now let me check the types and related files for context on …
-└─ ⠙ Explore  Explore codebase architecture  13🛠 · 4⟳ · ↑16k ↓2.9k 15.0%/128k (auto) · 12s
+└─ ⠙ Explore  Explore codebase architecture  13⚙︎ · 4⟳ · ↑16k ↓2.9k 15.0%/128k (auto) · 12s
    └ ## Architecture Summary: pi-subagents-lite
 ```
 
@@ -68,7 +68,7 @@ Background agents deliver a result notification when done:
 ```
  Subagent Result
 
- ✓ Explore (model-name)·13🛠 ·5⟳ ·↑25.9k↓4.9k 15%·21s
+ ✓ Explore (model-name)·13⚙︎ ·5⟳ ·↑25.9k↓4.9k 15%·21s
    Explore codebase architecture
    tail -f /tmp/pi-agent-outputs/4f6b0f08-7a9a-419.log
 ```
@@ -77,7 +77,7 @@ Foreground results land inline:
 
 ```
  ▸ Explore
- ✓ 31🛠 ·6⟳ ·↑48.1k↓9.2k 28%·39s
+ ✓ 31⚙︎ ·6⟳ ·↑48.1k↓9.2k 28%·39s
    Explore project directory structure
 ```
 
@@ -85,7 +85,7 @@ Stop a running agent from `/agents`:
 
 ```
 ○ Agents
-└─ ■ Agent  Code review of agent-runner.ts  12🛠 ·10⟳ ·↑32.8k↓6.2k 8%·52s stopped
+└─ ■ Agent  Code review of agent-runner.ts  12⚙︎ ·10⟳ ·↑32.8k↓6.2k 8%·52s stopped
     tail -f /tmp/pi-agent-outputs/23689696-3cd3-400.log
 ```
 
@@ -261,14 +261,14 @@ Persistent bar above the editor showing running and completed agents, updating l
 
 **Full mode** (tree, header + `tail -f` path + activity):
 ```
-├─ ⠙ Explore  description  3🛠 · 5≤30⟳ · ↑10k ↓1.8k R85k W3.0k CH89.2% $0.024 45.0%/128k (auto) · 1h 2m 3s
+├─ ⠙ Explore  description  3⚙︎ · 5≤30⟳ · ↑10k ↓1.8k R85k W3.0k CH89.2% $0.024 45.0%/128k (auto) · 1h 2m 3s
 │  │ tail -f /tmp/pi-agent-outputs/...
 │  └ thinking…
 ```
 
 **Compact mode** (single line, description truncated, activity inline):
 ```
-├─ ⠙ Explore  description trunc…  3🛠 · 5≤30⟳ · ↑10k ↓1.8k R85k W3.0k CH89.2% $0.024 45.0%/128k (auto) · 1h 2m 3s  thinking…
+├─ ⠙ Explore  description trunc…  3⚙︎ · 5≤30⟳ · ↑10k ↓1.8k R85k W3.0k CH89.2% $0.024 45.0%/128k (auto) · 1h 2m 3s  thinking…
 ```
 
 Turn format uses `≤` and `⟳` (`5≤30⟳` = 5 of 30 turns). Turn count is colored by usage: normal < 80%, warning 80–99%, error at 100%. The max is hidden when well below the limit. The contiguous usage group follows Pi: `↑input ↓output Rcache-read Wcache-write CHhit-rate $cost context/window (auto)`. Input visibility also controls cache fields; output, context, and cost remain independently configurable.
@@ -342,7 +342,7 @@ Fullscreen transcript viewer for agent sessions — opens automatically from `/a
 
 | Field | Default | Description |
 |---|---|---|
-| `showTools` | `true` | Tool count (🛠). |
+| `showTools` | `true` | Tool count (⚙︎). |
 | `showTurns` | `true` | Turn count (⟳). |
 | `showInput` | `true` | Input tokens (↑). |
 | `showOutput` | `true` | Output tokens (↓). |

--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ Running agents appear in the live widget:
 
 ```
 ◈ Agents
-├─ ⠙ Agent  Write model precedence unit tests  6⚙︎ · 3⟳ · ↑6.8k ↓1.3k 6.0%/128k (auto) · 12s
+├─ ⠙ Agent  Write model precedence unit tests  6⚙︎  3⟳  ↑6.8k ↓1.3k 6.0%/128k (auto)  12s
 │  │ tail -f /tmp/pi-agent-outputs/bb3382a9-1f7e-474.log
 │  └ The file already exists but is ~175 lines. The user wants a …
-├─ ⠙ Agent  Code review of agent-runner.ts  4⚙︎ · 2⟳ · ↑7.2k ↓1.5k 4.0%/128k (auto) · 12s
+├─ ⠙ Agent  Code review of agent-runner.ts  4⚙︎  2⟳  ↑7.2k ↓1.5k 4.0%/128k (auto)  12s
 │  └ Now let me check the types and related files for context on …
-└─ ⠙ Explore  Explore codebase architecture  13⚙︎ · 4⟳ · ↑16k ↓2.9k 15.0%/128k (auto) · 12s
+└─ ⠙ Explore  Explore codebase architecture  13⚙︎  4⟳  ↑16k ↓2.9k 15.0%/128k (auto)  12s
    └ ## Architecture Summary: pi-subagents-lite
 ```
 
@@ -261,14 +261,14 @@ Persistent bar above the editor showing running and completed agents, updating l
 
 **Full mode** (tree, header + `tail -f` path + activity):
 ```
-├─ ⠙ Explore  description  3⚙︎ · 5≤30⟳ · ↑10k ↓1.8k R85k W3.0k CH89.2% $0.024 45.0%/128k (auto) · 1h 2m 3s
+├─ ⠙ Explore  description  3⚙︎  5≤30⟳  ↑10k ↓1.8k R85k W3.0k CH89.2% $0.024 45.0%/128k (auto)  1h 2m 3s
 │  │ tail -f /tmp/pi-agent-outputs/...
 │  └ thinking…
 ```
 
 **Compact mode** (single line, description truncated, activity inline):
 ```
-├─ ⠙ Explore  description trunc…  3⚙︎ · 5≤30⟳ · ↑10k ↓1.8k R85k W3.0k CH89.2% $0.024 45.0%/128k (auto) · 1h 2m 3s  thinking…
+├─ ⠙ Explore  description trunc…  3⚙︎  5≤30⟳  ↑10k ↓1.8k R85k W3.0k CH89.2% $0.024 45.0%/128k (auto)  1h 2m 3s  thinking…
 ```
 
 Turn format uses `≤` and `⟳` (`5≤30⟳` = 5 of 30 turns). Turn count is colored by usage: normal < 80%, warning 80–99%, error at 100%. The max is hidden when well below the limit. The contiguous usage group follows Pi: `↑input ↓output Rcache-read Wcache-write CHhit-rate $cost context/window (auto)`. Input visibility also controls cache fields; output, context, and cost remain independently configurable.

--- a/README.md
+++ b/README.md
@@ -50,17 +50,15 @@ pi -e npm:pi-subagents-lite           # try without installing
 
 The LLM calls `Agent` like any other tool. Foreground agents return inline with stats; background agents acknowledge immediately and auto-deliver on completion.
 
-Running agents appear in the live widget:
+Agents appear in the live widget:
 
 ```
 ◈ Agents
-├─ ⠙ Agent  Write model precedence unit tests  6⚙︎  3⟳ · ↑6.8k ↓1.3k 6.0%/128k (auto) · 12s
-│  │ tail -f /tmp/pi-agent-outputs/bb3382a9-1f7e-474.log
-│  └ The file already exists but is ~175 lines. The user wants a …
-├─ ⠙ Agent  Code review of agent-runner.ts  4⚙︎  2⟳ · ↑7.2k ↓1.5k 4.0%/128k (auto) · 12s
-│  └ Now let me check the types and related files for context on …
-└─ ⠙ Explore  Explore codebase architecture  13⚙︎  4⟳ · ↑16k ↓2.9k 15.0%/128k (auto) · 12s
-   └ ## Architecture Summary: pi-subagents-lite
+  ⠙ 09:42 Agent    Write model precedence unit tests  6⚙︎  3⟳ · ↑6.8k ↓1.3k 6.0%/128k (auto) · 12s
+  │ tail -f /tmp/pi-agent-outputs/bb3382a9-1f7e-474.log
+  └ The file already exists but is ~175 lines. The user wants a …
+  ◇ 09:41 Agent    Review agent-runner.ts
+  ✓ 09:40 Explore  Explore codebase architecture  13⚙︎  4⟳ · ↑16k ↓2.9k 15.0%/128k (auto) · 12s
 ```
 
 Background agents deliver a result notification when done:
@@ -85,7 +83,7 @@ Stop a running agent from `/agents`:
 
 ```
 ○ Agents
-└─ ■ Agent  Code review of agent-runner.ts  12⚙︎  10⟳ · ↑32.8k ↓6.2k 8% · 52s stopped
+  ■ 09:42 Agent  Code review of agent-runner.ts  12⚙︎  10⟳ · ↑32.8k ↓6.2k 8% · 52s stopped
     tail -f /tmp/pi-agent-outputs/23689696-3cd3-400.log
 ```
 
@@ -257,18 +255,18 @@ Management menu with four sections:
 
 ### Live widget
 
-Persistent bar above the editor showing running and completed agents, updating live. Running agents show a spinner, current tool activity, turn count, Pi-compatible token/cache/cost usage, context window utilization, and elapsed time. Completed agents retain their final context and subscription snapshot. Click the `tail -f` path to follow output logs.
+Persistent bar above the editor showing running, queued, and completed agents in one newest-first list, updating live. `widgetShowModelThinking` controls one shared model-and-thinking column; when OFF, both values and their column are removed to free space. When `widgetShowStartTime` is ON (the default), every row shows its local creation/start time (`HH:MM`) directly after its status symbol; for queued agents this is the time it entered the queue. Running agents show a spinner, current tool activity, turn count, Pi-compatible token/cache/cost usage, context window utilization, and elapsed time. Completed agents retain their final context and subscription snapshot. Under overflow, running and queued rows take precedence over completed rows, then the visible rows are put back into newest-first order. Click the `tail -f` path to follow output logs.
 
-**Full mode** (tree, header + `tail -f` path + activity):
+**Full mode** (header + `tail -f` path + activity):
 ```
-├─ ⠙ Explore  description  3⚙︎  5≤30⟳ · ↑10k ↓1.8k R85k W3.0k CH89.2% $0.024 45.0%/128k (auto) · 1h 2m 3s
-│  │ tail -f /tmp/pi-agent-outputs/...
-│  └ thinking…
+  ⠙ 09:42 Explore  description  3⚙︎  5≤30⟳ · ↑10k ↓1.8k R85k W3.0k CH89.2% $0.024 45.0%/128k (auto) · 1h 2m 3s
+  │ tail -f /tmp/pi-agent-outputs/...
+  └ thinking…
 ```
 
 **Compact mode** (single line, description truncated, activity inline):
 ```
-├─ ⠙ Explore  description trunc…  3⚙︎  5≤30⟳ · ↑10k ↓1.8k R85k W3.0k CH89.2% $0.024 45.0%/128k (auto) · 1h 2m 3s  thinking…
+  ⠙ 09:42 Explore  description trunc…  3⚙︎  5≤30⟳ · ↑10k ↓1.8k R85k W3.0k CH89.2% $0.024 45.0%/128k (auto) · 1h 2m 3s  thinking…
 ```
 
 Turn format uses `≤` and `⟳` (`5≤30⟳` = 5 of 30 turns). Turn count is colored by usage: normal < 80%, warning 80–99%, error at 100%. The max is hidden when well below the limit. The contiguous usage group follows Pi: `↑input ↓output Rcache-read Wcache-write CHhit-rate $cost context/window (auto)`. Input visibility also controls cache fields; output, context, and cost remain independently configurable.
@@ -300,11 +298,18 @@ Fullscreen transcript viewer for agent sessions — opens automatically from `/a
     "showOutput": true,
     "showContext": true,
     "showTime": true,
+    "deltaInputTokens": false,
     "widgetMaxLines": 12,
     "widgetMaxLinesCompact": 6,
     "widgetDescLengthFull": 50,
+    "widgetDescLengthCompact": 30,
     "widgetCompact": true,
     "widgetShortcut": false,
+    "widgetShowModelThinking": true,
+    "widgetShowStartTime": true,
+    "widgetNavHint": true,
+    "outputThinkingBufferSize": 0,
+    "finishedRetentionMinutes": 10,
     "systemPromptMode": "inherit",
     "includeContextFiles": true,
     "loadSkillsImplicitly": false,
@@ -330,13 +335,18 @@ Fullscreen transcript viewer for agent sessions — opens automatically from `/a
 
 | Field | Default | Description |
 |---|---|---|
-| `widgetMaxLines` | `12` | Max body lines in full mode (excluding heading). |
-| `widgetMaxLinesCompact` | half of `widgetMaxLines` | Max body lines in compact mode. |
+| `widgetMaxLines` | `12` | Max total lines in full mode, including the heading. |
+| `widgetMaxLinesCompact` | half of `widgetMaxLines` | Max total lines in compact mode, including the heading. |
 | `widgetDescLengthFull` | `50` | Max description length in full mode. |
 | `widgetDescLengthCompact` | `30` | Max description length in compact mode. |
 | `widgetCompact` | `false` | Force compact mode regardless of ctrl+o state. |
 | `widgetShortcut` | `false` | When ON, ctrl+o (tool expansion toggle) syncs with widget compact mode. When OFF, compact is manual via `widgetCompact`. |
-| `outputThinkingBufferSize` | `200` | Thinking buffer ring size in chars. `0` = OFF. Flushes to output log at sentence boundaries. |
+| `widgetShowModelThinking` | `true` | Show one model-and-thinking column in every agent row. OFF removes the values and frees its space. |
+| `widgetShowStartTime` | `true` | Show each row's local `HH:MM` creation/start time. Queued rows show their queue-entry time. |
+| `widgetNavHint` | `true` | Show the `↓ to navigate` tip in the widget heading. |
+| `outputThinkingBufferSize` | `0` | Thinking buffer ring size in chars. `0` = OFF. Flushes to output log at sentence boundaries. |
+| `finishedRetentionMinutes` | `10` | Minutes to retain finished agents in the widget. |
+| `deltaInputTokens` | `false` | Estimate input-token deltas for vLLM-style providers without cache reporting. |
 
 ### Stats visibility
 

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Management menu with four sections:
   - **Spawn options** — force background, grace turns, default max turns, default thinking, disable default agents
   - **System prompt** — mode, custom prompt file, include AGENTS.md, load skills/extensions implicitly
   - **Concurrency** — default limit, per-provider and per-model slots (with search), reset to defaults
-  - **Widget settings** — force compact, max lines, description length, thinking buffer size, ctrl+o shortcut, usage stats (toggle tools, turns, input/output tokens, context %, cost, time)
+  - **Widget settings** — force compact, max lines, description length, thinking buffer size, ctrl+o shortcut, usage stats (toggle tools, turns, input/output tokens, context %, cost, time in the widget and conversation viewer)
 
 ## Interface
 
@@ -281,7 +281,7 @@ Fullscreen transcript viewer for agent sessions — opens automatically from `/a
 
 **Navigation:** `↑↓` / `PgUp/PgDn` scroll · `g`/`G` top/bottom · `Home`/`End` jump · `f` fullscreen · `r` refresh · `q`/`Esc` close.
 
-**Stats line:** `15⟳ · ↑12k ↓8.0k R85k W3.0k CH89.2% $0.024 47.0%/128k (auto) · 47s`. The same Pi-compatible usage group is used by foreground and background result cards; cost remains controlled by **Cost display**.
+**Stats line:** `15⟳ · ↑12k ↓8.0k R85k W3.0k CH89.2% $0.024 47.0%/128k (auto) · 47s`. The configured stats-visibility toggles also apply here, including **Cost display**. The same Pi-compatible usage group is used by foreground and background result cards.
 
 ## Configuration
 
@@ -339,6 +339,8 @@ Fullscreen transcript viewer for agent sessions — opens automatically from `/a
 | `outputThinkingBufferSize` | `200` | Thinking buffer ring size in chars. `0` = OFF. Flushes to output log at sentence boundaries. |
 
 ### Stats visibility
+
+These toggles apply to the live widget and conversation viewer.
 
 | Field | Default | Description |
 |---|---|---|

--- a/src/agents/agent-manager.ts
+++ b/src/agents/agent-manager.ts
@@ -20,7 +20,7 @@ import {
   type ToolActivity,
 } from "../types.js";
 import type { SubagentType } from "./types.js";
-import { addUsage, getLifetimeTotal, getSessionContextPercent, type AgentUsage } from "./usage.js";
+import { addUsage, getLifetimeTotal, getSessionUsageSnapshot, type AgentUsage } from "./usage.js";
 import { errorMessage } from "../utils.js";
 
 /** How often to check for expired agent records (milliseconds). */
@@ -235,6 +235,7 @@ export class AgentManager {
         toolUses: 0,
         turnCount: 1,
         compactionCount: 0,
+        cacheRead: 0,
         maxTurns: options.maxTurns,
       },
     };
@@ -321,7 +322,6 @@ export class AgentManager {
         }
         record.result = responseText;
         record.execution.session = session;
-        record.stats.contextPercent = getSessionContextPercent(session);
         record.lifecycle.completedAt ??= Date.now();
         return responseText;
       })
@@ -335,6 +335,16 @@ export class AgentManager {
         return "";
       })
       .finally(() => {
+        // Session handles are not guaranteed to remain usable after completion,
+        // so retain the footer values that terminal cards need before cleanup.
+        const snapshot = getSessionUsageSnapshot(record.execution.session);
+        if (snapshot) {
+          record.stats.contextPercent = snapshot.contextPercent;
+          record.stats.contextWindow = snapshot.contextWindow;
+          record.stats.autoCompactionEnabled = snapshot.autoCompactionEnabled;
+          record.stats.usingSubscription = snapshot.usingSubscription;
+        }
+
         // Finalize output log with final stats
         if (record.execution.outputLog) {
           try {
@@ -403,6 +413,11 @@ export class AgentManager {
         record.stats.prevInputTokens = usage.input;
 
         addUsage(record.stats.lifetimeUsage, { ...usage, input: inputDelta });
+        record.stats.cacheRead += usage.cacheRead;
+        const promptTokens = usage.input + usage.cacheRead + usage.cacheWrite;
+        record.stats.latestCacheHitRate = promptTokens > 0
+          ? (usage.cacheRead / promptTokens) * 100
+          : undefined;
         options?.onAssistantUsage?.(usage);
       },
       onCompaction: (info) => {

--- a/src/agents/agent-manager.ts
+++ b/src/agents/agent-manager.ts
@@ -394,6 +394,7 @@ export class AgentManager {
   ): {
     onToolActivity: (activity: ToolActivity) => void;
     onAssistantUsage: (usage: AgentUsage) => void;
+    onSupplementalUsage: (usage: AgentUsage) => void;
     onCompaction: (info: CompactionInfo) => void;
   } {
     return {
@@ -419,6 +420,12 @@ export class AgentManager {
           ? (usage.cacheRead / promptTokens) * 100
           : undefined;
         options?.onAssistantUsage?.(usage);
+      },
+      // Compaction and tool-result usage is billable but is not an assistant
+      // request, so it must bypass the vLLM input-delta and cache-hit logic.
+      onSupplementalUsage: (usage) => {
+        addUsage(record.stats.lifetimeUsage, usage);
+        record.stats.cacheRead += usage.cacheRead;
       },
       onCompaction: (info) => {
         record.stats.compactionCount++;

--- a/src/agents/agent-manager.ts
+++ b/src/agents/agent-manager.ts
@@ -84,6 +84,9 @@ export class AgentManager {
   /** Session-level cumulative agent cost. Survives agent eviction. */
   private totalAgentCost = 0;
 
+  /** Session-level cumulative accepted agent count. Survives agent eviction. */
+  private totalAgentCount = 0;
+
   /** Retention cutoff in minutes for finished agents. Updated at runtime via setRetentionMinutes. */
   private retentionMinutes = DEFAULT_RETENTION_MINUTES;
 
@@ -241,15 +244,21 @@ export class AgentManager {
     };
     this.agents.set(id, record);
 
-    if (queued) return id;
+    // Queued agents have been successfully accepted even though their start is deferred.
+    if (queued) {
+      this.totalAgentCount++;
+      return id;
+    }
 
-    // startAgent can throw — clean up record so callers don't see an orphan
+    // startAgent can throw — clean up record so callers don't see an orphan.
+    // Count only after a synchronous start succeeds.
     try {
       this.startAgent(id, record, args, concurrencySlot);
     } catch (err) {
       this.agents.delete(id);
       throw err;
     }
+    this.totalAgentCount++;
     return id;
   }
 
@@ -381,6 +390,11 @@ export class AgentManager {
   /** Get the session-level cumulative agent cost. Survives agent eviction. */
   getTotalAgentCost(): number {
     return this.totalAgentCost;
+  }
+
+  /** Get the session-level cumulative accepted agent count. Survives agent eviction. */
+  getTotalAgentCount(): number {
+    return this.totalAgentCount;
   }
 
   /**

--- a/src/agents/agent-runner.ts
+++ b/src/agents/agent-runner.ts
@@ -6,6 +6,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import type { Usage } from "@earendil-works/pi-ai";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
   type AgentSession,
@@ -105,8 +106,15 @@ function normalizeMaxTurns(n: number | undefined): number | undefined {
   return Math.max(1, n);
 }
 
-/** Info about a tool event in the subagent. */
-interface RunOptions extends RunTunables, RunCallbacks {
+/**
+ * Internal usage channel for billable work that is not an assistant turn.
+ * These usages must not affect assistant-only input-delta or cache-hit metrics.
+ */
+interface SupplementalUsageCallbacks {
+  onSupplementalUsage?: (usage: AgentUsage) => void;
+}
+
+interface RunOptions extends RunTunables, RunCallbacks, SupplementalUsageCallbacks {
   /** ExtensionAPI instance — used for pi.exec() for git detection. */
   pi: ExtensionAPI;
   /** Manager-assigned id; suffixes session name to disambiguate parallel spawns (e.g. `Explore#a1b2c3d4`). */
@@ -187,15 +195,26 @@ function usageFromAssistantMessage(msg: Record<string, unknown>): AgentUsage | u
   };
 }
 
+/** Convert typed upstream usage from compaction or tool results to local accounting. */
+function usageFromTypedUsage(usage: Usage): AgentUsage {
+  return {
+    input: usage.input,
+    output: usage.output,
+    cacheWrite: usage.cacheWrite,
+    cacheRead: usage.cacheRead,
+    cost: usage.cost.total,
+  };
+}
+
 /**
  * Subscribe to shared session events (tool activity, usage, compaction)
  * used by runAgent. Returns an unsubscribe function.
  */
 export function subscribeToSessionEvents(
   session: AgentSession,
-  options: Pick<RunOptions, "onToolActivity" | "onAssistantUsage" | "onCompaction">,
+  options: Pick<RunOptions, "onToolActivity" | "onAssistantUsage" | "onSupplementalUsage" | "onCompaction">,
 ): () => void {
-  if (!options.onToolActivity && !options.onAssistantUsage && !options.onCompaction) {
+  if (!options.onToolActivity && !options.onAssistantUsage && !options.onSupplementalUsage && !options.onCompaction) {
     return () => {};
   }
   return session.subscribe((event: AgentSessionEvent) => {
@@ -212,7 +231,13 @@ export function subscribeToSessionEvents(
         options.onAssistantUsage?.(usage);
       }
     }
+    if (event.type === "message_end" && event.message.role === "toolResult" && event.message.usage) {
+      options.onSupplementalUsage?.(usageFromTypedUsage(event.message.usage));
+    }
     if (event.type === "compaction_end" && !event.aborted && event.result) {
+      if (event.result.usage) {
+        options.onSupplementalUsage?.(usageFromTypedUsage(event.result.usage));
+      }
       options.onCompaction?.({ reason: event.reason, tokensBefore: event.result.tokensBefore });
     }
   });

--- a/src/agents/output-file.ts
+++ b/src/agents/output-file.ts
@@ -9,7 +9,7 @@
 import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { AgentSession, AgentSessionEvent } from "@earendil-works/pi-coding-agent";
-import { formatTokens } from "./usage.js";
+import { formatCost, formatTokens } from "./usage.js";
 import { summarizeToolArgs } from "../ui/format.js";
 
 
@@ -29,7 +29,7 @@ function findLastSentenceBoundary(text: string): number {
 /** Format the [DONE] summary line with final stats. */
 function formatDoneLine(stats: { turnCount: number; toolUseCount: number; totalTokens: number; cost: number }): string {
   const tokensStr = `${formatTokens(stats.totalTokens)} tokens`;
-  const costStr = `$${stats.cost.toFixed(3)}`;
+  const costStr = formatCost(stats.cost);
   return `${timestamp()} [DONE] ${stats.turnCount} turns, ${stats.toolUseCount} tool uses, ${tokensStr}, ${costStr}\n`;
 }
 /** Max content length for full tool result display — longer results get a summary line. */

--- a/src/agents/tool-execution.ts
+++ b/src/agents/tool-execution.ts
@@ -12,7 +12,7 @@ import type { ExtensionContext, ToolCallEvent } from "@earendil-works/pi-coding-
 import type { AgentRecord } from "../types.js";
 import { SHORT_ID_LENGTH } from "../types.js";
 import { resolveType, getAgentConfig, discoverNewAgents } from "./agent-types.js";
-import { getLifetimeTotal, getSessionContextPercent } from "./usage.js";
+import { getSessionUsageSnapshot } from "./usage.js";
 import { validateWorktreePath } from "../spawn/worktree-validator.js";
 
 import { parseModelKey, findModelInRegistry, parseThinkingLevel } from "../utils.js";
@@ -76,12 +76,31 @@ export function buildAgentDetails(
     details.turnCount = record.stats.turnCount;
     details.maxTurns = record.stats.maxTurns;
     details.toolUses = record.stats.toolUses;
+    const liveSnapshot = getSessionUsageSnapshot(record.execution.session);
+    const terminalSnapshot = {
+      contextPercent: record.stats.contextPercent,
+      contextWindow: record.stats.contextWindow,
+      autoCompactionEnabled: record.stats.autoCompactionEnabled,
+      usingSubscription: record.stats.usingSubscription,
+    };
+    const usageSnapshot = record.lifecycle.completedAt != null
+      && (terminalSnapshot.contextPercent != null || terminalSnapshot.contextWindow != null)
+      ? terminalSnapshot
+      : (liveSnapshot ?? terminalSnapshot);
+
     details.input = record.stats.lifetimeUsage.input;
     details.output = record.stats.lifetimeUsage.output;
-    details.contextPercent = getSessionContextPercent(record.execution.session);
+    details.cacheRead = record.stats.cacheRead;
+    details.cacheWrite = record.stats.lifetimeUsage.cacheWrite;
+    details.latestCacheHitRate = record.stats.latestCacheHitRate;
+    details.contextPercent = usageSnapshot.contextPercent ?? null;
+    details.contextWindow = usageSnapshot.contextWindow;
+    details.autoCompactionEnabled = usageSnapshot.autoCompactionEnabled;
+    details.usingSubscription = usageSnapshot.usingSubscription;
     details.durationMs = elapsedMs;
     details.compactions = record.stats.compactionCount;
     details.modelName = record.display.invocation?.modelName;
+    details.thinkingLevel = record.display.invocation?.thinkingLevel;
     details.cost = record.stats.lifetimeUsage.cost;
   }
 
@@ -176,7 +195,7 @@ export async function executeAgentTool(
     graceTurns: getStore().agent.graceTurns,
     worktreePath: validatedWorktreePath,
     worktreeLabel,
-    invocation: { modelName },
+    invocation: { modelName, thinkingLevel },
     runInBackground: runInBackground || getStore().agent.forceBackground,
   });
 

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -1,11 +1,9 @@
 /** usage.ts — Token usage: shapes, accumulator operators, session-stats readers. */
 
 /**
- * Lifetime usage components, accumulated via `message_end` events. Survives
- * compaction (which replaces session.state.messages and would reset any
- * stats-derived sum). cacheRead is excluded because each turn's cacheRead is
- * the cumulative cached prefix re-read on that one call — summing across
- * turns counts the prefix N times. See issue #38.
+ * Billable token usage accumulated from `message_end` events. Cache reads are
+ * tracked separately on AgentAccumulatedStats so their Pi display total can be
+ * maintained without changing this long-standing lifetime usage shape.
  */
 export type LifetimeUsage = { input: number; output: number; cacheWrite: number; cost: number };
 
@@ -16,9 +14,9 @@ export type LifetimeUsage = { input: number; output: number; cacheWrite: number;
  */
 export type AgentUsage = LifetimeUsage & { cacheRead: number };
 
-/** Sum of lifetime usage components (including cost), or 0 if undefined. */
+/** Sum of lifetime token components (never dollar cost), or 0 if undefined. */
 export function getLifetimeTotal(u?: LifetimeUsage): number {
-  return u ? u.input + u.output + u.cacheWrite + u.cost : 0;
+  return u ? u.input + u.output + u.cacheWrite : 0;
 }
 
 /** Add a usage delta into a target accumulator (mutates target). */
@@ -29,31 +27,66 @@ export function addUsage(into: LifetimeUsage, delta: LifetimeUsage): void {
   into.cost += delta.cost;
 }
 
-/** Minimal shape we read from upstream `getSessionStats()`. */
-type SessionStatsLike = {
-  tokens: { input: number; output: number; cacheWrite: number };
-  contextUsage?: { percent: number | null };
+/** Minimal session surface used by UI accounting. Methods are optional for test doubles. */
+export type SessionLike = {
+  getSessionStats?: () => { contextUsage?: { percent: number | null; contextWindow?: number } };
+  getContextUsage?: () => { percent: number | null; contextWindow: number } | undefined;
+  autoCompactionEnabled?: boolean;
+  model?: { provider?: string; contextWindow?: number };
+  state?: { model?: { provider?: string; contextWindow?: number } };
+  modelRuntime?: { isUsingOAuth?: (provider: string) => boolean };
 };
-export type SessionLike = { getSessionStats(): SessionStatsLike };
 
-/** Format a token count compactly: "12.3k", "1.2M", or raw number. When compact is true, thousands round to whole numbers. */
-export function formatTokens(count: number, compact = false): string {
-  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
-  if (count >= 1_000) return compact ? `${Math.round(count / 1_000)}k` : `${(count / 1_000).toFixed(1)}k`;
-  return `${count}`;
+/** Context/auth values which must survive after an AgentSession is no longer live. */
+export interface SessionUsageSnapshot {
+  contextPercent: number | null;
+  contextWindow?: number;
+  autoCompactionEnabled?: boolean;
+  usingSubscription?: boolean;
 }
 
-/** Format cost as a dollar amount: "$0.00", "$0.01", "$1.23". */
+/** Format a token count exactly like Pi's interactive footer. */
+export function formatTokens(count: number, _compact?: boolean): string {
+  if (count < 1_000) return count.toString();
+  if (count < 10_000) return `${(count / 1_000).toFixed(1)}k`;
+  if (count < 1_000_000) return `${Math.round(count / 1_000)}k`;
+  if (count < 10_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
+  return `${Math.round(count / 1_000_000)}M`;
+}
+
+/** Format cost exactly like Pi's interactive footer. */
 export function formatCost(cost: number): string {
-  return `$${cost.toFixed(2)}`;
+  return `$${cost.toFixed(3)}`;
 }
 
-/**
- * Context-window utilization (0–100), or null when unavailable
- * (no model contextWindow, or post-compaction before the next response).
- */
+/** Read Pi context and authentication state defensively, including model fallback. */
+export function getSessionUsageSnapshot(session: SessionLike | undefined): SessionUsageSnapshot | undefined {
+  if (!session) return undefined;
+  try {
+    const contextUsage = session.getContextUsage?.() ?? session.getSessionStats?.().contextUsage;
+    const model = session.model ?? session.state?.model;
+    const contextWindow = contextUsage?.contextWindow ?? model?.contextWindow;
+    const provider = model?.provider;
+    let usingSubscription: boolean | undefined;
+    if (provider) {
+      usingSubscription = provider === "kimi-coding";
+      if (!usingSubscription) {
+        try { usingSubscription = session.modelRuntime?.isUsingOAuth?.(provider) ?? false; }
+        catch { usingSubscription = false; }
+      }
+    }
+    return {
+      contextPercent: contextUsage?.percent ?? null,
+      ...(typeof contextWindow === "number" ? { contextWindow } : {}),
+      ...(typeof session.autoCompactionEnabled === "boolean" ? { autoCompactionEnabled: session.autoCompactionEnabled } : {}),
+      ...(usingSubscription !== undefined ? { usingSubscription } : {}),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+/** Context-window utilization (0–100), or null when unavailable. */
 export function getSessionContextPercent(session: SessionLike | undefined): number | null {
-  if (!session) return null;
-  try { return session.getSessionStats().contextUsage?.percent ?? null; }
-  catch { return null; }
+  return getSessionUsageSnapshot(session)?.contextPercent ?? null;
 }

--- a/src/config/config-io.ts
+++ b/src/config/config-io.ts
@@ -7,9 +7,10 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import type { SubagentsConfig } from "../models/model-precedence.js";
 
-const CONFIG_DIR = path.join(process.env.HOME || "", ".pi", "agent");
+const CONFIG_DIR = getAgentDir();
 const CONFIG_PATH = path.join(CONFIG_DIR, "subagents-lite.json");
 /** Path to custom prompt file for subagent system prompts. */
 export const CUSTOM_PROMPT_PATH = path.join(CONFIG_DIR, "subagents-lite-prompt.md");

--- a/src/config/config-io.ts
+++ b/src/config/config-io.ts
@@ -33,6 +33,8 @@ const DEFAULT_AGENT: SubagentsConfig["agent"] = {
   widgetDescLengthCompact: 30,
   widgetCompact: false,
   widgetShortcut: false,
+  widgetShowModelThinking: true,
+  widgetShowStartTime: true,
   widgetNavHint: true,
   systemPromptMode: "replace",
   includeContextFiles: true,
@@ -45,6 +47,7 @@ const DEFAULT_AGENT: SubagentsConfig["agent"] = {
   showCost: false,
   showTime: true,
   deltaInputTokens: false,
+  outputThinkingBufferSize: 0,
   finishedRetentionMinutes: 10,
 };
 

--- a/src/config/config-store.ts
+++ b/src/config/config-store.ts
@@ -46,6 +46,8 @@ export interface ResolvedAgentSettings {
   readonly widgetMaxLinesCompact: number;
   readonly widgetCompact: boolean;
   readonly widgetShortcut: boolean;
+  readonly widgetShowModelThinking: boolean;
+  readonly widgetShowStartTime: boolean;
   readonly widgetNavHint: boolean;
   readonly widgetDescLengthFull: number;
   readonly widgetDescLengthCompact: number;
@@ -95,7 +97,7 @@ export class ConfigStore {
   private sessionShowCost: boolean | undefined;
   private widget?: AgentWidget;
   private manager?: AgentManager;
-  /** Previous tool-expansion state, for ctrl+o compact sync. */
+  /** Last known tool-expansion state, for ctrl+o compact sync. */
   private lastToolsExpanded: boolean | undefined;
 
   constructor(private readonly io: ConfigIO = fileConfigIO) {
@@ -111,8 +113,8 @@ export class ConfigStore {
 
   get agent(): ResolvedAgentSettings {
     const a = this.config.agent;
-    const widgetMaxLines = a.widgetMaxLines!; // guaranteed by loadConfig default merge
-    const widgetMaxLinesCompact = a.widgetMaxLinesCompact ?? Math.floor(widgetMaxLines / 2);
+    const widgetMaxLines = Math.max(2, a.widgetMaxLines!); // guaranteed by loadConfig default merge
+    const widgetMaxLinesCompact = Math.max(2, a.widgetMaxLinesCompact ?? Math.floor(widgetMaxLines / 2));
 
     return {
       defaultModel: a.default ?? null,
@@ -123,6 +125,8 @@ export class ConfigStore {
       widgetMaxLinesCompact,
       widgetCompact: a.widgetCompact === true,
       widgetShortcut: a.widgetShortcut === true,
+      widgetShowModelThinking: a.widgetShowModelThinking !== false,
+      widgetShowStartTime: a.widgetShowStartTime !== false,
       widgetNavHint: a.widgetNavHint !== false,
       widgetDescLengthFull: a.widgetDescLengthFull ?? 50,
       widgetDescLengthCompact: a.widgetDescLengthCompact ?? 30,
@@ -293,17 +297,19 @@ export class ConfigStore {
         this.config.agent.widgetCompact = enabled;
         this.persist();
         this.syncWidgetSettings();
+        this.syncCompactModeFromToolsExpanded();
       },
       setMaxLines: (lines: number): void => {
-        this.config.agent.widgetMaxLines = lines;
+        const maxLines = Math.max(2, lines);
+        this.config.agent.widgetMaxLines = maxLines;
         if (this.config.agent.widgetMaxLinesCompact === undefined) {
-          this.config.agent.widgetMaxLinesCompact = Math.floor(lines / 2);
+          this.config.agent.widgetMaxLinesCompact = Math.max(2, Math.floor(maxLines / 2));
         }
         this.persist();
         this.syncWidgetSettings();
       },
       setMaxLinesCompact: (lines: number): void => {
-        this.config.agent.widgetMaxLinesCompact = lines;
+        this.config.agent.widgetMaxLinesCompact = Math.max(2, lines);
         this.persist();
         this.syncWidgetSettings();
       },
@@ -317,13 +323,21 @@ export class ConfigStore {
         this.persist();
         this.syncWidgetSettings();
       },
-      // Note: persists only. Does NOT syncWidgetSettings — matches the existing
-      // behavior, where toggling the shortcut takes effect on next reload rather
-      // than immediately. Flagged for a follow-up (the other three widget
-      // setters do sync).
       setShortcut: (enabled: boolean): void => {
         this.config.agent.widgetShortcut = enabled;
         this.persist();
+        this.syncWidgetSettings();
+        this.syncCompactModeFromToolsExpanded();
+      },
+      setShowModelThinking: (enabled: boolean): void => {
+        this.config.agent.widgetShowModelThinking = enabled;
+        this.persist();
+        this.syncWidgetSettings();
+      },
+      setShowStartTime: (enabled: boolean): void => {
+        this.config.agent.widgetShowStartTime = enabled;
+        this.persist();
+        this.syncWidgetSettings();
       },
       setNavHint: (enabled: boolean): void => {
         this.config.agent.widgetNavHint = enabled;
@@ -392,23 +406,14 @@ export class ConfigStore {
   // ── ctrl+o compact sync (absorbs syncCompactFromToolsExpanded) ──
 
   /**
-   * Toggle widget compact mode when tool expansion changes (ctrl+o), gated on
-   * widgetShortcut. No-op when widgetCompact is forced on. Only acts on actual
-   * state transitions (not every call).
+   * Sync widget compact mode from the known tool-expansion state (ctrl+o),
+   * gated on widgetShortcut. The first known state and later state changes both
+   * apply immediately; force compact overrides this coupling.
    */
   notifyToolsExpanded(expanded: boolean): void {
-    if (this.config.agent.widgetShortcut !== true) {
-      this.lastToolsExpanded = expanded;
-      return;
-    }
-    if (this.config.agent.widgetCompact === true) {
-      this.lastToolsExpanded = expanded;
-      return;
-    }
-    if (this.lastToolsExpanded !== undefined && this.lastToolsExpanded !== expanded) {
-      this.widget?.setCompactMode(!expanded);
-    }
+    const changed = this.lastToolsExpanded !== expanded;
     this.lastToolsExpanded = expanded;
+    if (changed) this.syncCompactModeFromToolsExpanded();
   }
 
   // ── Lifecycle ──────────────────────────────────────────────────
@@ -441,6 +446,15 @@ export class ConfigStore {
     this.io.save(this.config);
   }
 
+  /** Apply the last known tool-expansion state while shortcut coupling is active. */
+  private syncCompactModeFromToolsExpanded(): void {
+    if (this.config.agent.widgetShortcut === true
+      && this.config.agent.widgetCompact !== true
+      && this.lastToolsExpanded !== undefined) {
+      this.widget?.setCompactMode(!this.lastToolsExpanded);
+    }
+  }
+
   /** Push widget display settings (compact, shortcut, max lines) to the widget. */
   private syncWidgetSettings(): void {
     const w = this.widget;
@@ -448,6 +462,8 @@ export class ConfigStore {
     const a = this.agent;
     w.setForceCompact(a.widgetCompact);
     w.setWidgetShortcut(a.widgetShortcut);
+    w.setShowModelThinking(a.widgetShowModelThinking);
+    w.setShowStartTime(a.widgetShowStartTime);
     w.setMaxLines(a.widgetMaxLines);
     w.setMaxLinesCompact(a.widgetMaxLinesCompact);
     w.setDescLengthFull(a.widgetDescLengthFull);
@@ -487,6 +503,7 @@ export class ConfigStore {
     if (this.widget) {
       this.widget.setShowCost(this.agent.showCost);
       this.syncWidgetSettings();
+      this.syncCompactModeFromToolsExpanded();
       this.syncWidgetStatsVisibility();
     }
     this.applyConcurrency();

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -17,6 +17,8 @@ export const CONFIG_AGENT_NON_MODEL_KEYS = [
   "widgetDescLengthCompact",
   "widgetCompact",
   "widgetShortcut",
+  "widgetShowModelThinking",
+  "widgetShowStartTime",
   "widgetNavHint",
   "systemPromptMode",
   "includeContextFiles",

--- a/src/events.ts
+++ b/src/events.ts
@@ -133,6 +133,7 @@ async function openViewer(ctx: ExtensionContext, record: AgentRecord | null): Pr
           () => manager?.abort(record.id, "user"),
           kb,
           (msg: string) => manager?.steer(record.id, msg),
+          getStore().agent,
         ),
       { overlay: true, overlayOptions: { anchor: "center", width: "90%", maxHeight: `${VIEWPORT_HEIGHT_PCT}%` } },
     );

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,7 +1,7 @@
 import type { AgentRecord } from "./types.js";
 
 import * as path from "node:path";
-import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { getAgentDir, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { matchesKey, isKeyRelease } from "@earendil-works/pi-tui";
 import { registerAgents, getAvailableTypes, setAgentScanDirs, scanAndMerge } from "./agents/agent-types.js";
 import { AgentManager } from "./agents/agent-manager.js";
@@ -79,8 +79,7 @@ export function ensureManagerAndWidget(): void {
  * and register into the type registry.
  */
 export async function scanAndRegisterAgents(ctx: ExtensionContext): Promise<void> {
-  const homeDir = process.env.HOME || "";
-  const userAgentDir = path.join(homeDir, ".pi", "agent", "agents");
+  const userAgentDir = path.join(getAgentDir(), "agents");
   const sharedAgentDir = path.join(ctx.cwd, ".agents", "agents");
   const projectAgentDir = path.join(ctx.cwd, ".pi", "agents");
 

--- a/src/models/model-precedence.ts
+++ b/src/models/model-precedence.ts
@@ -26,6 +26,12 @@ export interface SubagentsConfig {
     widgetMaxLinesCompact?: number;
     widgetCompact?: boolean;
     widgetShortcut?: boolean;
+    /** Whether to show model names and thinking levels in widget rows. Default: true. */
+    widgetShowModelThinking?: boolean;
+    /** Whether to show local HH:MM start time in widget rows. Default: true. */
+    widgetShowStartTime?: boolean;
+    /** Whether to show the navigation tip in the widget heading. Default: true. */
+    widgetNavHint?: boolean;
     /** System prompt mode: replace (default), inherit parent, or custom file. */
     systemPromptMode?: SystemPromptMode;
     /** Whether to include AGENTS.md context files in the subagent system prompt. Default: true. */

--- a/src/prompt/skill-loader.ts
+++ b/src/prompt/skill-loader.ts
@@ -6,7 +6,7 @@
  * Roots, in precedence order (first match wins by name):
  *   1. Ancestor .agents/skills (cwd → git root, root .md files filtered out)
  *   2. ~/.agents/skills (root .md files filtered out)
- *   3. ~/.pi/agent/skills (Pi's user default)
+ *   3. Pi's user agent directory skills (Pi's user default)
  *   4. <cwd>/.pi/skills (Pi's project default)
  *
  * Pi's loadSkills handles: .gitignore/.ignore/.fdignore, symlinks (follow +
@@ -21,6 +21,7 @@ import { readFileSync, realpathSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import {
+  getAgentDir,
   loadSkills,
   loadSkillsFromDir,
   type Skill,
@@ -69,10 +70,10 @@ export function loadAllSkills(cwd: string): Skill[] {
     join(homedir(), ".agents", "skills"),
   );
 
-  // Pi defaults: ~/.pi/agent/skills and <cwd>/.pi/skills
+  // Pi defaults: Pi's user agent directory and <cwd>/.pi/skills
   const defaultsResult = loadSkills({
     cwd: resolvedCwd,
-    agentDir: join(homedir(), ".pi", "agent"),
+    agentDir: getAgentDir(),
     skillPaths: [],
     includeDefaults: true,
   });

--- a/src/registration.ts
+++ b/src/registration.ts
@@ -39,7 +39,6 @@ export function registerAgentTool(pi: ExtensionAPI): void {
       worktree_path: Type.Optional(Type.String()),
     }, { additionalProperties: false }),
     execute: executeAgentTool,
-    constrainedSampling: CONSTRAINED_SAMPLING,
 
     renderCall: (args: Record<string, unknown>, theme: any) => renderAgentToolCall(args, theme),
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -168,8 +168,15 @@ export interface AgentAccumulatedStats {
   compactionCount: number;
   /** Previous input token count for delta estimation (vLLM doesn't report cache hits). */
   prevInputTokens?: number;
-  /** Last-known context usage percentage (0–100), captured at completion. */
+  /** Pi-style cumulative cache reads (each request's cache prefix is counted). */
+  cacheRead: number;
+  /** Cache hit rate from the most recent usage event. */
+  latestCacheHitRate?: number;
+  /** Final context/auth snapshot, retained after the live session is gone. */
   contextPercent?: number | null;
+  contextWindow?: number;
+  autoCompactionEnabled?: boolean;
+  usingSubscription?: boolean;
 }
 
 

--- a/src/ui/agent-widget.ts
+++ b/src/ui/agent-widget.ts
@@ -34,7 +34,8 @@ const WIDGET_REFRESH_INTERVAL = 80;
 /** Fixed horizontal gaps between the aligned agent columns. */
 const NAME_COLUMN_GAP = "  ";
 const MODEL_THINKING_COLUMN_GAP = "  ";
-const ROW_PREFIX_WIDTH = 4; // two-space indent, status icon, and following space
+const ROW_PREFIX_WIDTH_WITH_START_TIME = 10; // indent, status icon, HH:MM time, and gaps
+const ROW_PREFIX_WIDTH_WITHOUT_START_TIME = 4; // indent, status icon, and following gap
 const STATS_COLUMN_GAP_WIDTH = 2;
 const ACTIVITY_COLUMN_GAP_WIDTH = 2;
 
@@ -60,6 +61,7 @@ interface TUI {
 }
 /** A visual block: one header line plus zero or more continuation lines. */
 interface RenderBlock {
+  agent: AgentRecord;
   header: string;
   continuations: string[];
 }
@@ -102,6 +104,23 @@ function buildWorktreeOutputParts(a: AgentRecord): string[] {
   return parts;
 }
 
+/** Format an agent's local creation/start time in a fixed, locale-independent HH:MM form. */
+function formatStartTime(startedAt: number): string {
+  if (!Number.isFinite(startedAt)) return "--:--";
+  const date = new Date(startedAt);
+  if (Number.isNaN(date.getTime())) return "--:--";
+  return `${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}`;
+}
+
+/** Sort agents newest-first while preserving manager order for equal or invalid timestamps. */
+function sortByStartedAt(agents: AgentRecord[]): AgentRecord[] {
+  return [...agents].sort((a, b) => {
+    const aStartedAt = Number.isFinite(a.lifecycle.startedAt) ? a.lifecycle.startedAt : Number.NEGATIVE_INFINITY;
+    const bStartedAt = Number.isFinite(b.lifecycle.startedAt) ? b.lifecycle.startedAt : Number.NEGATIVE_INFINITY;
+    return bStartedAt > aStartedAt ? 1 : bStartedAt < aStartedAt ? -1 : 0;
+  });
+}
+
 // ---- Widget manager ----
 
 export class AgentWidget {
@@ -134,6 +153,12 @@ export class AgentWidget {
 
   /** Whether ctrl+o shortcut is enabled (syncs compact with toolsExpanded). */
   private widgetShortcut = false;
+
+  /** Whether to show model names and thinking levels in each agent row. */
+  private showModelThinking = true;
+
+  /** Whether to show local HH:MM start time in each agent row. */
+  private showStartTime = true;
 
   /** Maximum lines for full mode. */
   private maxLines = DEFAULT_MAX_WIDGET_LINES;
@@ -191,20 +216,34 @@ export class AgentWidget {
     this.widgetShortcut = enabled;
   }
 
+  /** Set whether model names and thinking levels are shown in agent rows. */
+  setShowModelThinking(enabled: boolean) {
+    if (this.showModelThinking === enabled) return;
+    this.showModelThinking = enabled;
+    this.update();
+  }
+
+  /** Set whether local HH:MM start time is shown in agent rows. */
+  setShowStartTime(enabled: boolean) {
+    if (this.showStartTime === enabled) return;
+    this.showStartTime = enabled;
+    this.update();
+  }
+
   /** Notify widget that tool expansion state changed (push-based, no polling). */
   notifyToolsExpansionChanged(expanded: boolean) {
     this.pendingToolsExpanded = expanded;
     this.update();
   }
 
-  /** Set max lines for full mode. */
+  /** Set max total lines for full mode, including the heading. */
   setMaxLines(lines: number) {
-    this.maxLines = lines;
+    this.maxLines = Math.max(2, lines);
   }
 
-  /** Set max lines for compact mode. */
+  /** Set max total lines for compact mode, including the heading. */
   setMaxLinesCompact(lines: number) {
-    this.maxLinesCompact = lines;
+    this.maxLinesCompact = Math.max(2, lines);
   }
 
   /** Set max description length for full mode. */
@@ -234,10 +273,9 @@ export class AgentWidget {
     }
   }
 
-  /** Build the navigation roster: running, queued, finished. */
+  /** Build the navigation roster in the same newest-first order as the widget. */
   private buildRoster(): AgentRecord[] {
-    const { running, queued, finished } = this.categorizeAgents();
-    return [...running, ...queued, ...finished];
+    return this.categorizeAgents().ordered;
   }
 
   /** Enter navigation mode. Highlights the first agent (index 0) when one exists. */
@@ -345,18 +383,28 @@ export class AgentWidget {
     }
   }
 
-  /** Categorize all agents into running, queued, and finished groups. */
+  /**
+   * Categorize visible agents while retaining one global newest-first order.
+   * Equal timestamps keep the manager's original order, including across statuses.
+   */
   private categorizeAgents() {
-    const allAgents = this.manager.listAgents();
+    const ordered: AgentRecord[] = [];
     const running: AgentRecord[] = [];
     const queued: AgentRecord[] = [];
     const finished: AgentRecord[] = [];
-    for (const a of allAgents) {
-      if (a.lifecycle.status === "running") running.push(a);
-      else if (a.lifecycle.status === "queued") queued.push(a);
-      else if (a.lifecycle.completedAt) finished.push(a);
+    for (const a of sortByStartedAt(this.manager.listAgents())) {
+      if (a.lifecycle.status === "running") {
+        ordered.push(a);
+        running.push(a);
+      } else if (a.lifecycle.status === "queued") {
+        ordered.push(a);
+        queued.push(a);
+      } else if (a.lifecycle.completedAt) {
+        ordered.push(a);
+        finished.push(a);
+      }
     }
-    return { running, queued, finished };
+    return { ordered, running, queued, finished };
   }
 
   /** Build the icon and status suffix for a finished agent. */
@@ -404,8 +452,19 @@ export class AgentWidget {
 
   /** Get a model/thinking label at the available terminal width before applying styling. */
   private displayModelThinking(a: AgentRecord, maxWidth?: number): string {
+    if (!this.showModelThinking) return "";
     const label = this.modelThinkingLabel(a);
     return maxWidth == null ? label : truncateToWidth(label, maxWidth);
+  }
+
+  /** Width used by the row's indent, status symbol, and optional start time. */
+  private rowPrefixWidth(): number {
+    return this.showStartTime ? ROW_PREFIX_WIDTH_WITH_START_TIME : ROW_PREFIX_WIDTH_WITHOUT_START_TIME;
+  }
+
+  /** Render the optional local start time after a status symbol. */
+  private renderStartTime(a: AgentRecord, theme: Theme, color: string): string {
+    return this.showStartTime ? ` ${theme.fg(color, formatStartTime(a.lifecycle.startedAt))}` : "";
   }
 
   /** Build shared terminal-width columns for visible individual agent rows. */
@@ -426,7 +485,7 @@ export class AgentWidget {
           return visibleWidth(live ? describeActivity(live.activeTools, live.responseText) : "thinking…");
         }))
       : 0;
-    const reservedWidth = ROW_PREFIX_WIDTH
+    const reservedWidth = this.rowPrefixWidth()
       + naturalLayout.nameWidth
       + visibleWidth(NAME_COLUMN_GAP)
       + STATS_COLUMN_GAP_WIDTH
@@ -501,7 +560,7 @@ export class AgentWidget {
     const modelThinking = padToVisibleWidth(this.displayModelThinking(a, layout.modelThinkingWidth), layout.modelThinkingWidth);
     const description = padToVisibleWidth(this.displayDescription(a, layout.descriptionWidth), layout.descriptionWidth);
     const { icon, statusText } = this.finishedIconAndStatus(a.lifecycle.status, a.error, theme);
-    return `${icon} ${theme.fg("dim", name)}${NAME_COLUMN_GAP}${this.renderModelThinkingColumn(modelThinking, theme, layout)}${theme.fg("dim", description)}  ${wrapInDim(theme, rawStats)}${statusText}`;
+    return `${icon}${this.renderStartTime(a, theme, "dim")} ${theme.fg("dim", name)}${NAME_COLUMN_GAP}${this.renderModelThinkingColumn(modelThinking, theme, layout)}${theme.fg("dim", description)}  ${wrapInDim(theme, rawStats)}${statusText}`;
   }
 
   /** Build RenderBlocks for finished (completed/errored) agents. */
@@ -523,6 +582,7 @@ export class AgentWidget {
         }
       }
       blocks.push({
+        agent: a,
         header: truncate(`  ${this.renderFinishedLine(a, theme, layout, statsLines.get(a.id) ?? "")}`),
         continuations,
       });
@@ -553,15 +613,16 @@ export class AgentWidget {
       if (this.isCompact()) {
         // Compact: single line with activity inline, truncated description
         const desc = padToVisibleWidth(this.displayDescription(a, layout.descriptionWidth), layout.descriptionWidth);
-        const headerLine = `  ${theme.fg("accent", frame)} ${theme.fg("text", theme.bold(name))}${NAME_COLUMN_GAP}${modelThinkingColumn}${theme.fg("text", desc)}  ${statsLine}  ${theme.fg("text", activity)}`;
+        const headerLine = `  ${theme.fg("accent", frame)}${this.renderStartTime(a, theme, "text")} ${theme.fg("text", theme.bold(name))}${NAME_COLUMN_GAP}${modelThinkingColumn}${theme.fg("text", desc)}  ${statsLine}  ${theme.fg("text", activity)}`;
         blocks.push({
+          agent: a,
           header: truncate(headerLine),
           continuations: [],
         });
       } else {
         // Full: header + continuation lines
         const description = padToVisibleWidth(this.displayDescription(a, layout.descriptionWidth), layout.descriptionWidth);
-        const headerLine = `  ${theme.fg("accent", frame)} ${theme.fg("text", theme.bold(name))}${NAME_COLUMN_GAP}${modelThinkingColumn}${theme.fg("text", description)}  ${statsLine}`;
+        const headerLine = `  ${theme.fg("accent", frame)}${this.renderStartTime(a, theme, "text")} ${theme.fg("text", theme.bold(name))}${NAME_COLUMN_GAP}${modelThinkingColumn}${theme.fg("text", description)}  ${statsLine}`;
         const continuations: string[] = [];
         const parts = buildWorktreeOutputParts(a);
         if (parts.length > 0) {
@@ -569,25 +630,13 @@ export class AgentWidget {
         }
         continuations.push(truncate(theme.fg("text", "  └ " + activity)));
         blocks.push({
+          agent: a,
           header: truncate(headerLine),
           continuations,
         });
       }
     }
     return blocks;
-  }
-
-  /** Build a single RenderBlock for queued agents, or undefined if none. */
-  private buildQueuedBlock(
-    queued: AgentRecord[],
-    theme: Theme,
-    w: number,
-  ): RenderBlock | undefined {
-    if (queued.length === 0) return undefined;
-    const truncate = (line: string) => truncateToWidth(line, w);
-    const statusDisplay = getAgentStatusDisplay("queued");
-    const header = `  ${theme.fg(statusDisplay.color, statusDisplay.icon)} ${theme.fg("dim", `${queued.length} queued`)}`;
-    return { header: truncate(header), continuations: [] };
   }
 
   /**
@@ -601,7 +650,7 @@ export class AgentWidget {
 
   private renderWidget(tui: TUI | undefined, theme: Theme): string[] {
     if (!tui) return [];
-    const { running, queued, finished } = this.categorizeAgents();
+    const { ordered, running, queued, finished } = this.categorizeAgents();
 
     const hasActive = running.length > 0 || queued.length > 0;
     const hasFinished = finished.length > 0;
@@ -614,9 +663,9 @@ export class AgentWidget {
     const headingDisplay = getAgentStatusDisplay(running.length > 0 ? "running" : "queued");
     const frame = SPINNER[this.widgetFrame % SPINNER.length];
 
-    // Build blocks — separate arrays so rendering and overflow use the same priority:
-    // running → queued → finished. Running and completed rows share one stats
-    // layout; queued rows deliberately have no stats.
+    // Build blocks individually. Running and queued agents are prioritized over
+    // finished ones only while choosing an overflow subset; the rendered list is
+    // always globally newest-first by creation/start time.
     const statCells = new Map<string, StatsCells>();
     for (const agent of [...running, ...finished]) statCells.set(agent.id, this.buildStatsCells(agent, theme));
     const statsLayout = buildStatsLayout([...statCells.values()]);
@@ -624,29 +673,16 @@ export class AgentWidget {
     for (const agent of [...running, ...finished]) {
       statsLines.set(agent.id, formatStatsRow(statCells.get(agent.id)!, statsLayout) ?? "");
     }
-    const layout = this.buildAgentColumnLayout([
-      ...running,
-      ...(this.navActive ? queued : []),
-      ...finished,
-    ], w, statsLines);
+    const layout = this.buildAgentColumnLayout([...running, ...queued, ...finished], w, statsLines);
     const finishedBlocks = this.buildFinishedBlocks(finished, theme, w, layout, statsLines);
     const runningBlocks = this.buildRunningBlocks(running, theme, w, frame, layout, statsLines);
+    const queuedBlocks = this.buildQueuedIndividualBlocks(queued, theme, w, layout);
 
-    // Queued: individual rows during nav, aggregated block otherwise.
-    let queuedBlocks: RenderBlock[];
-    if (this.navActive) {
-      queuedBlocks = this.buildQueuedIndividualBlocks(queued, theme, w, layout);
-    } else {
-      const aggregated = this.buildQueuedBlock(queued, theme, w);
-      queuedBlocks = aggregated ? [aggregated] : [];
-    }
-
-    // All blocks in display order: running → queued → finished.
-    const blocks: RenderBlock[] = [
+    const blocks = this.orderBlocks([
       ...runningBlocks,
       ...queuedBlocks,
       ...finishedBlocks,
-    ];
+    ], ordered);
 
     // ---- Overflow logic (works with blocks, not lines) ----
 
@@ -666,18 +702,18 @@ export class AgentWidget {
       // Everything fits — render all blocks with correct connectors.
       lines.push(...this.renderBlocks(blocks, highlightedBlockIndex, theme));
     } else {
-      // Pin the highlighted block so it's always visible during navigation.
-      // blocks is already [...runningBlocks, ...queuedBlocks, ...finishedBlocks].
+      // Pin the highlighted block so it remains visible during navigation.
       const pinnedBlock = highlightedBlockIndex >= 0 && highlightedBlockIndex < blocks.length
         ? blocks[highlightedBlockIndex]
         : undefined;
       const { visible, overflowLine } = this.applyOverflow(
-        runningBlocks, queuedBlocks, finishedBlocks, maxBody, theme, pinnedBlock,
+        runningBlocks, queuedBlocks, finishedBlocks, ordered, maxBody, theme, pinnedBlock,
       );
-      // The pinned block is the highlighted one; find it among the visible blocks
-      // (it won't appear if it failed to fit).
-      const visIndex = pinnedBlock ? visible.indexOf(pinnedBlock) : -1;
-      lines.push(...this.renderBlocks(visible, visIndex, theme));
+      const visibleInDisplayOrder = this.orderBlocks(visible, ordered);
+      const visIndex = pinnedBlock
+        ? visibleInDisplayOrder.findIndex((block) => block.agent === pinnedBlock.agent)
+        : -1;
+      lines.push(...this.renderBlocks(visibleInDisplayOrder, visIndex, theme));
       if (overflowLine) lines.push(truncate(overflowLine));
     }
 
@@ -694,7 +730,7 @@ export class AgentWidget {
     return `${iconText}  ${theme.fg("dim", "↓ to navigate")}`;
   }
 
-  /** Build individual RenderBlocks for each queued agent (used during navigation). */
+  /** Build individual RenderBlocks for queued agents. */
   private buildQueuedIndividualBlocks(
     queued: AgentRecord[], theme: Theme, w: number, layout: AgentColumnLayout,
   ): RenderBlock[] {
@@ -705,10 +741,16 @@ export class AgentWidget {
       const name = padToVisibleWidth(getDisplayName(a.display.type), layout.nameWidth);
       const modelThinking = padToVisibleWidth(this.displayModelThinking(a, layout.modelThinkingWidth), layout.modelThinkingWidth);
       const desc = padToVisibleWidth(this.displayDescription(a, layout.descriptionWidth), layout.descriptionWidth);
-      const header = `  ${theme.fg(statusDisplay.color, statusDisplay.icon)} ${theme.fg("dim", name)}${NAME_COLUMN_GAP}${this.renderModelThinkingColumn(modelThinking, theme, layout)}${theme.fg("dim", desc)}`;
-      blocks.push({ header: truncate(header), continuations: [] });
+      const header = `  ${theme.fg(statusDisplay.color, statusDisplay.icon)}${this.renderStartTime(a, theme, "dim")} ${theme.fg("dim", name)}${NAME_COLUMN_GAP}${this.renderModelThinkingColumn(modelThinking, theme, layout)}${theme.fg("dim", desc)}`;
+      blocks.push({ agent: a, header: truncate(header), continuations: [] });
     }
     return blocks;
+  }
+
+  /** Order blocks according to the stable global manager order for this render. */
+  private orderBlocks(blocks: RenderBlock[], orderedAgents: AgentRecord[]): RenderBlock[] {
+    const positions = new Map(orderedAgents.map((agent, index) => [agent, index]));
+    return [...blocks].sort((a, b) => positions.get(a.agent)! - positions.get(b.agent)!);
   }
 
   private renderBlock(block: RenderBlock, _isLast: boolean, isHighlighted: boolean, theme: Theme): string[] {
@@ -725,69 +767,85 @@ export class AgentWidget {
     return blocks.flatMap((b, i) => this.renderBlock(b, i === blocks.length - 1, i === highlightedBlockIndex, theme));
   }
 
+  /** Number of terminal rows consumed by a block in the current widget mode. */
+  private blockHeight(block: RenderBlock): number {
+    return 1 + block.continuations.length;
+  }
+
+  /** Return a block cut to the available terminal-row budget, retaining its header. */
+  private truncateBlockToHeight(block: RenderBlock, maxHeight: number): RenderBlock | undefined {
+    if (maxHeight < 1) return undefined;
+    return { ...block, continuations: block.continuations.slice(0, maxHeight - 1) };
+  }
+
   /**
-   * Overflow logic — prioritize running > queued > finished.
-   * Reserve 1 line for the overflow summary indicator.
-   * When `pinned` is provided (navigation mode), reserve it a slot first so the
-   * highlighted block is always visible even if it would be pushed off by priority.
+   * Overflow logic — prioritize active (running/queued) blocks over finished ones.
+   * Reserve a row for the overflow summary when doing so still leaves room for a
+   * row header. A pinned block is shortened to the remaining budget so navigation
+   * never exceeds the configured line limit.
    */
   private applyOverflow(
     runningBlocks: RenderBlock[],
     queuedBlocks: RenderBlock[],
     finishedBlocks: RenderBlock[],
+    orderedAgents: AgentRecord[],
     maxBody: number,
     theme: Theme,
     pinned: RenderBlock | undefined = undefined,
   ): { visible: RenderBlock[]; overflowLine?: string } {
-    let budget = maxBody - 1;
+    const reserveOverflowLine = maxBody >= 2;
+    let budget = maxBody - (reserveOverflowLine ? 1 : 0);
     let hiddenRunning = 0;
     let hiddenQueued = 0;
     let hiddenFinished = 0;
     const visible: RenderBlock[] = [];
 
-    // Pin the highlighted block first (navigation mode)
+    // Pin the highlighted block first (navigation mode), trimming continuation
+    // rows if needed. The copied block still carries the same agent identity.
     if (pinned) {
-      const pinnedHeight = 1 + pinned.continuations.length;
-      if (budget >= pinnedHeight) {
-        visible.push(pinned);
-        budget -= pinnedHeight;
-      }
-      // If pinned block doesn't fit, still push it — it displaces lowest-priority content
-      else if (budget > 0) {
-        visible.push(pinned);
-        budget = 0;
+      const visiblePinned = this.truncateBlockToHeight(pinned, budget);
+      if (visiblePinned) {
+        visible.push(visiblePinned);
+        budget -= this.blockHeight(visiblePinned);
       }
     }
 
-    // 1. Running blocks (highest priority)
-    for (const b of runningBlocks) {
-      if (b === pinned) continue; // already placed
-      const height = 1 + b.continuations.length;
-      if (budget >= height) {
-        visible.push(b);
-        budget -= height;
-      } else {
-        hiddenRunning++;
-      }
-    }
+    const activeBlocks = this.orderBlocks([...runningBlocks, ...queuedBlocks], orderedAgents);
+    const visibleActive: Array<{ source: RenderBlock; block: RenderBlock }> = [];
 
-    // 2. Queued blocks
-    for (const b of queuedBlocks) {
+    // 1. Give every active block a header before spending rows on continuations.
+    // This keeps a running or queued agent visible when its full block does not
+    // fit, and prevents a finished row from displacing it.
+    for (const b of activeBlocks) {
       if (b === pinned) continue; // already placed
-      if (budget >= 1) {
-        visible.push(b);
+      const headerOnly = this.truncateBlockToHeight(b, 1);
+      if (headerOnly && budget >= 1) {
+        visible.push(headerOnly);
+        visibleActive.push({ source: b, block: headerOnly });
         budget--;
+      } else if (b.agent.lifecycle.status === "running") {
+        hiddenRunning++;
       } else {
         hiddenQueued++;
       }
     }
 
-    // 3. Finished blocks (lowest priority)
-    for (const b of finishedBlocks) {
+    // 2. Restore active continuations in stable global order before showing
+    // finished blocks, without displacing another active header.
+    for (const { source, block } of visibleActive) {
+      const continuationCount = Math.min(source.continuations.length, budget);
+      if (continuationCount === 0) continue;
+      block.continuations = source.continuations.slice(0, continuationCount);
+      budget -= continuationCount;
+    }
+
+    // 3. Finished blocks (lowest priority, in stable global order)
+    for (const b of this.orderBlocks(finishedBlocks, orderedAgents)) {
       if (b === pinned) continue; // already placed
-      if (budget >= 1) {
+      const height = this.blockHeight(b);
+      if (budget >= height) {
         visible.push(b);
-        budget--;
+        budget -= height;
       } else {
         hiddenFinished++;
       }
@@ -795,7 +853,7 @@ export class AgentWidget {
 
     // Overflow summary line
     let overflowLine: string | undefined;
-    if (hiddenRunning + hiddenQueued + hiddenFinished > 0) {
+    if (reserveOverflowLine && hiddenRunning + hiddenQueued + hiddenFinished > 0) {
       const parts: string[] = [];
       if (hiddenRunning > 0) parts.push(`${hiddenRunning} running`);
       if (hiddenQueued > 0) parts.push(`${hiddenQueued} queued`);

--- a/src/ui/agent-widget.ts
+++ b/src/ui/agent-widget.ts
@@ -153,7 +153,7 @@ export class AgentWidget {
   /** Navigation mode active. */
   private navActive = false;
 
-  /** Current highlight position in the roster (0 = main). */
+  /** Current highlight position in the roster (0 = first agent). */
   private _highlightedIndex = 0;
 
   /** Viewer overlay open — prevents deactivation while ResultViewer is displayed. */
@@ -234,13 +234,13 @@ export class AgentWidget {
     }
   }
 
-  /** Build the navigation roster: finished, running, queued. */
+  /** Build the navigation roster: running, queued, finished. */
   private buildRoster(): AgentRecord[] {
-    const { finished, running, queued } = this.categorizeAgents();
-    return [...finished, ...running, ...queued];
+    const { running, queued, finished } = this.categorizeAgents();
+    return [...running, ...queued, ...finished];
   }
 
-  /** Enter navigation mode. Highlights the first agent (index 1) if agents exist, else main (index 0). */
+  /** Enter navigation mode. Highlights the first agent (index 0) when one exists. */
   navActivate(): void {
     if (this.navActive) return;
     this.navActive = true;
@@ -248,7 +248,7 @@ export class AgentWidget {
     this.update();
   }
 
-  /** Move highlight down one position. Wraps from last agent to main. */
+  /** Move highlight down one position. Wraps from the last agent to the first. */
   navDown(): void {
     if (!this.navActive) return;
     const roster = this.buildRoster();
@@ -257,7 +257,7 @@ export class AgentWidget {
     this._highlightedIndex = (this._highlightedIndex + 1) % roster.length;
     this.update();
   }
-  /** Move highlight up one position. Wraps from main to last agent. */
+  /** Move highlight up one position. Wraps from the first agent to the last. */
   navUp(): void {
     if (!this.navActive) return;
     const roster = this.buildRoster();
@@ -286,7 +286,7 @@ export class AgentWidget {
     return this.navActive;
   }
 
-  /** Current highlight position (0 = main). */
+  /** Current highlight position (0 = first roster agent). */
   highlightedIndex(): number {
     return this._highlightedIndex;
   }
@@ -627,13 +627,13 @@ export class AgentWidget {
     const headingDisplay = getAgentStatusDisplay(running.length > 0 ? "running" : "queued");
     const frame = SPINNER[this.widgetFrame % SPINNER.length];
 
-    // Build blocks — separate arrays so overflow logic can apply priority: running > queued > finished.
-    // Align all individually rendered agent rows. The aggregate queued row deliberately
-    // remains unchanged outside navigation mode.
+    // Build blocks — separate arrays so rendering and overflow use the same priority:
+    // running → queued → finished. Align all individually rendered agent rows. The
+    // aggregate queued row deliberately remains unchanged outside navigation mode.
     const layout = this.buildAgentColumnLayout([
-      ...finished,
       ...running,
       ...(this.navActive ? queued : []),
+      ...finished,
     ], theme, w);
     const finishedBlocks = this.buildFinishedBlocks(finished, theme, w, layout);
     const runningBlocks = this.buildRunningBlocks(running, theme, w, frame, layout);
@@ -647,11 +647,11 @@ export class AgentWidget {
       queuedBlocks = aggregated ? [aggregated] : [];
     }
 
-    // All blocks in display order: finished → running → queued.
+    // All blocks in display order: running → queued → finished.
     const blocks: RenderBlock[] = [
-      ...finishedBlocks,
       ...runningBlocks,
       ...queuedBlocks,
+      ...finishedBlocks,
     ];
 
     // ---- Overflow logic (works with blocks, not lines) ----
@@ -673,7 +673,7 @@ export class AgentWidget {
       lines.push(...this.renderBlocks(blocks, highlightedBlockIndex, theme));
     } else {
       // Pin the highlighted block so it's always visible during navigation.
-      // blocks is already [...finishedBlocks, ...runningBlocks, ...queuedBlocks].
+      // blocks is already [...runningBlocks, ...queuedBlocks, ...finishedBlocks].
       const pinnedBlock = highlightedBlockIndex >= 0 && highlightedBlockIndex < blocks.length
         ? blocks[highlightedBlockIndex]
         : undefined;

--- a/src/ui/agent-widget.ts
+++ b/src/ui/agent-widget.ts
@@ -864,8 +864,8 @@ export class AgentWidget {
 
     return { visible, overflowLine };
   }
-  /** Clear widget and status bar. */
-  private clearWidget() {
+  /** Clear widget and, unless retained for session history, the status bar. */
+  private clearWidget(clearStatus = true) {
     // Deactivate navigation when agents clear
     if (this.navActive) {
       this.navActive = false;
@@ -876,7 +876,7 @@ export class AgentWidget {
       this.widgetRegistered = false;
       this.tui = undefined;
     }
-    if (this.lastStatusText !== undefined) {
+    if (clearStatus && this.lastStatusText !== undefined) {
       this.uiCtx?.setStatus(STATUS_KEY, undefined);
       this.lastStatusText = undefined;
     }
@@ -892,11 +892,12 @@ export class AgentWidget {
   }
 
   /** Update the status bar text, only if it changed. */
-  private updateStatusBar(runningCount: number, queuedCount: number, finishedCount: number, running: AgentRecord[]) {
+  private updateStatusBar(runningCount: number, queuedCount: number, running: AgentRecord[]) {
     const activeCount = runningCount + queuedCount;
-    const activeText = activeCount > 0 ? `${activeCount} agent${activeCount === 1 ? "" : "s"}` : "";
-    const finishedText = finishedCount > 0 ? `${finishedCount} finished${finishedCount === 1 ? " agent" : " agents"}` : "";
-    let statusText = [activeText, finishedText].filter(Boolean).join(" · ");
+    const totalCount = this.manager.getTotalAgentCount();
+    const activeText = activeCount > 0 ? `${activeCount} active` : "";
+    const totalText = `${totalCount} agent${totalCount === 1 ? "" : "s"} total`;
+    let statusText = [activeText, totalText].filter(Boolean).join(" · ");
     if (this.showCost) {
       const sessionCost = this.manager.getTotalAgentCost();
       // Also include in-flight running agents (not yet completed, so not in accumulator)
@@ -933,16 +934,19 @@ export class AgentWidget {
     const hasActive = running.length > 0 || queued.length > 0;
     const hasFinished = finished.length > 0;
 
-    // Nothing to show — clear widget if registered, then early-return
+    // Nothing to render — retain the session summary after finished-record eviction.
     if (!hasActive && !hasFinished) {
-      if (this.widgetRegistered || this.lastStatusText !== undefined) {
+      if (this.manager.getTotalAgentCount() > 0) {
+        this.clearWidget(false);
+        this.updateStatusBar(0, 0, []);
+      } else if (this.widgetRegistered || this.lastStatusText !== undefined) {
         this.clearWidget();
       }
       return;
     }
 
     // Status bar — only call setStatus when the text actually changes
-    this.updateStatusBar(running.length, queued.length, finished.length, running);
+    this.updateStatusBar(running.length, queued.length, running);
 
     this.widgetFrame++;
 

--- a/src/ui/agent-widget.ts
+++ b/src/ui/agent-widget.ts
@@ -8,7 +8,7 @@ import type { AgentManager } from "../agents/agent-manager.js";
 import type { AgentRecord, AgentStatus } from "../types.js";
 import type { Theme } from "./types.js";
 import { formatCost, getSessionUsageSnapshot } from "../agents/usage.js";
-import { formatMs, buildStatsParts, formatThinkingTag, getAgentStatusDisplay, getDisplayName, truncateDesc, describeActivity, type StatsVisibility } from "./format.js";
+import { formatMs, buildStatsParts, formatThinkingTag, getAgentStatusDisplay, getDisplayName, truncateDesc, describeActivity, fgPreservingNestedStyles, type StatsVisibility } from "./format.js";
 import type { LiveView } from "../spawn/spawn-coordinator.js";
 
 // Re-export Theme so existing consumers (searchable-select, result-viewer) don't break
@@ -42,6 +42,8 @@ const ACTIVITY_COLUMN_GAP_WIDTH = 2;
 
 
 export type UICtx = {
+  /** Pi UI theme; optional for test and legacy UI contexts. */
+  theme?: Pick<Theme, "fg">;
   setStatus(key: string, text: string | undefined): void;
   setWidget(
     key: string,
@@ -389,8 +391,8 @@ export class AgentWidget {
     const modelName = typeof invocation?.modelName === "string" && invocation.modelName.trim()
       ? invocation.modelName.trim()
       : undefined;
-    const thinkingTag = formatThinkingTag(invocation?.thinkingLevel);
-    const parts = [modelName, thinkingTag].filter((part): part is string => part !== undefined);
+    const thinkingLevel = formatThinkingTag(invocation?.thinkingLevel);
+    const parts = [modelName, thinkingLevel].filter((part): part is string => part !== undefined);
     return parts.length > 0 ? `(${parts.join(" · ")})` : "";
   }
 
@@ -449,9 +451,10 @@ export class AgentWidget {
     modelThinking: string,
     theme: Theme,
     layout: AgentColumnLayout,
+    color = "dim",
   ): string {
     return layout.modelThinkingWidth > 0
-      ? `${theme.fg("dim", modelThinking)}${MODEL_THINKING_COLUMN_GAP}`
+      ? `${theme.fg(color, modelThinking)}${MODEL_THINKING_COLUMN_GAP}`
       : "";
   }
 
@@ -514,7 +517,7 @@ export class AgentWidget {
       ...this.usageSnapshot(agent),
       durationMs: Date.now() - agent.lifecycle.startedAt,
     }, theme, this.statsVisibility);
-    return parts.join(" · ");
+    return fgPreservingNestedStyles(theme, "text", parts.join(" · "));
   }
 
   /** Build RenderBlocks for finished (completed/errored) agents. */
@@ -555,7 +558,7 @@ export class AgentWidget {
     for (const a of running) {
       const name = padToVisibleWidth(getDisplayName(a.display.type), layout.nameWidth);
       const modelThinking = padToVisibleWidth(this.displayModelThinking(a, layout.modelThinkingWidth), layout.modelThinkingWidth);
-      const modelThinkingColumn = this.renderModelThinkingColumn(modelThinking, theme, layout);
+      const modelThinkingColumn = this.renderModelThinkingColumn(modelThinking, theme, layout, "text");
       const bg = this.getLiveView(a.id);
       const statsLine = this.buildStatsLine(a, theme);
       const activity = bg ? describeActivity(bg.activeTools, bg.responseText) : "thinking…";
@@ -563,7 +566,7 @@ export class AgentWidget {
       if (this.isCompact()) {
         // Compact: single line with activity inline, truncated description
         const desc = padToVisibleWidth(this.displayDescription(a, layout.descriptionWidth), layout.descriptionWidth);
-        const headerLine = `  ${theme.fg("accent", frame)} ${theme.bold(name)}${NAME_COLUMN_GAP}${modelThinkingColumn}${desc}  ${statsLine}  ${theme.fg("dim", activity)}`;
+        const headerLine = `  ${theme.fg("accent", frame)} ${theme.fg("text", theme.bold(name))}${NAME_COLUMN_GAP}${modelThinkingColumn}${theme.fg("text", desc)}  ${statsLine}  ${theme.fg("text", activity)}`;
         blocks.push({
           header: truncate(headerLine),
           continuations: [],
@@ -571,13 +574,13 @@ export class AgentWidget {
       } else {
         // Full: header + continuation lines
         const description = padToVisibleWidth(this.displayDescription(a, layout.descriptionWidth), layout.descriptionWidth);
-        const headerLine = `  ${theme.fg("accent", frame)} ${theme.bold(name)}${NAME_COLUMN_GAP}${modelThinkingColumn}${description}  ${statsLine}`;
+        const headerLine = `  ${theme.fg("accent", frame)} ${theme.fg("text", theme.bold(name))}${NAME_COLUMN_GAP}${modelThinkingColumn}${theme.fg("text", description)}  ${statsLine}`;
         const continuations: string[] = [];
         const parts = buildWorktreeOutputParts(a);
         if (parts.length > 0) {
-          continuations.push(truncate(theme.fg("dim", "  │ " + parts.join("  "))));
+          continuations.push(truncate(theme.fg("text", "  │ " + parts.join("  "))));
         }
-        continuations.push(truncate(theme.fg("dim", "  └ " + activity)));
+        continuations.push(truncate(theme.fg("text", "  └ " + activity)));
         blocks.push({
           header: truncate(headerLine),
           continuations,
@@ -831,6 +834,11 @@ export class AgentWidget {
     // when there are no agents, so there's no cost to keeping it alive.
   }
 
+  /** Apply Pi's semantic footer text token, falling back for older/test UI contexts. */
+  private styleStatusText(text: string): string {
+    return this.uiCtx?.theme?.fg("dim", text) ?? text;
+  }
+
   /** Update the status bar text, only if it changed. */
   private updateStatusBar(runningCount: number, queuedCount: number, finishedCount: number, running: AgentRecord[]) {
     const activeCount = runningCount + queuedCount;
@@ -845,7 +853,7 @@ export class AgentWidget {
       if (totalCost > 0) statusText += `: ${formatCost(totalCost)}`;
     }
     if (statusText !== this.lastStatusText) {
-      this.uiCtx?.setStatus(STATUS_KEY, statusText);
+      this.uiCtx?.setStatus(STATUS_KEY, this.styleStatusText(statusText));
       this.lastStatusText = statusText;
     }
   }
@@ -906,6 +914,10 @@ export class AgentWidget {
             this.widgetRegistered = false;
             this.tui = undefined;
             this.theme = undefined;
+            // Status text is rendered outside this widget, so restyle it explicitly.
+            if (this.lastStatusText !== undefined) {
+              this.uiCtx?.setStatus(STATUS_KEY, this.styleStatusText(this.lastStatusText));
+            }
           },
         };
       }, { placement: "aboveEditor" });

--- a/src/ui/agent-widget.ts
+++ b/src/ui/agent-widget.ts
@@ -5,10 +5,10 @@
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { getSessionCtx } from "../shell.js";
 import type { AgentManager } from "../agents/agent-manager.js";
-import type { AgentRecord } from "../types.js";
+import type { AgentRecord, AgentStatus } from "../types.js";
 import type { Theme } from "./types.js";
 import { formatCost, getSessionUsageSnapshot } from "../agents/usage.js";
-import { formatMs, buildStatsParts, formatThinkingTag, getDisplayName, truncateDesc, describeActivity, type StatsVisibility } from "./format.js";
+import { formatMs, buildStatsParts, formatThinkingTag, getAgentStatusDisplay, getDisplayName, truncateDesc, describeActivity, type StatsVisibility } from "./format.js";
 import type { LiveView } from "../spawn/spawn-coordinator.js";
 
 // Re-export Theme so existing consumers (searchable-select, result-viewer) don't break
@@ -359,24 +359,27 @@ export class AgentWidget {
 
   /** Build the icon and status suffix for a finished agent. */
   private finishedIconAndStatus(
-    status: string,
+    status: AgentStatus,
     error: string | undefined,
     theme: Theme,
   ): { icon: string; statusText: string } {
+    const display = getAgentStatusDisplay(status);
+    const icon = theme.fg(display.color, display.icon);
     switch (status) {
       case "completed":
-        return { icon: theme.fg("success", "✓"), statusText: "" };
+        return { icon, statusText: "" };
       case "turn_limited":
-        return { icon: theme.fg("warning", "✓"), statusText: theme.fg("warning", " (turn limit)") };
+        return { icon, statusText: theme.fg("warning", " (turn limit)") };
       case "stopped":
-        return { icon: theme.fg("dim", "■"), statusText: theme.fg("dim", " stopped") };
+        return { icon, statusText: theme.fg("dim", " stopped") };
       case "error": {
         const errMsg = error ? `: ${error.slice(0, 60)}` : "";
-        return { icon: theme.fg("error", "✗"), statusText: theme.fg("error", ` error${errMsg}`) };
+        return { icon, statusText: theme.fg("error", ` error${errMsg}`) };
       }
+      case "aborted":
+        return { icon, statusText: theme.fg("warning", " aborted") };
       default:
-        // aborted
-        return { icon: theme.fg("error", "✗"), statusText: theme.fg("warning", " aborted") };
+        return { icon, statusText: "" };
     }
   }
 
@@ -592,7 +595,8 @@ export class AgentWidget {
   ): RenderBlock | undefined {
     if (queued.length === 0) return undefined;
     const truncate = (line: string) => truncateToWidth(line, w);
-    const header = `  ${theme.fg("muted", "◦")} ${theme.fg("dim", `${queued.length} queued`)}`;
+    const statusDisplay = getAgentStatusDisplay("queued");
+    const header = `  ${theme.fg(statusDisplay.color, statusDisplay.icon)} ${theme.fg("dim", `${queued.length} queued`)}`;
     return { header: truncate(header), continuations: [] };
   }
 
@@ -617,8 +621,7 @@ export class AgentWidget {
 
     const w = tui.terminal.columns;
     const truncate = (line: string) => truncateToWidth(line, w);
-    const headingColor = hasActive ? "accent" : "dim";
-    const headingIcon = hasActive ? "◈" : "◇";
+    const headingDisplay = getAgentStatusDisplay(running.length > 0 ? "running" : "queued");
     const frame = SPINNER[this.widgetFrame % SPINNER.length];
 
     // Build blocks — separate arrays so overflow logic can apply priority: running > queued > finished.
@@ -655,7 +658,7 @@ export class AgentWidget {
     const totalBody = blocks.reduce((sum, b) => sum + 1 + b.continuations.length, 0);
 
     // Heading with navigation hint
-    const heading = this.buildHeading(theme, headingColor, headingIcon);
+    const heading = this.buildHeading(theme, headingDisplay.color, headingDisplay.icon);
     const lines: string[] = [truncate(heading)];
 
     // Determine highlighted block index for rendering the '>' marker.
@@ -700,11 +703,12 @@ export class AgentWidget {
   ): RenderBlock[] {
     const truncate = (line: string) => truncateToWidth(line, w);
     const blocks: RenderBlock[] = [];
+    const statusDisplay = getAgentStatusDisplay("queued");
     for (const a of queued) {
       const name = padToVisibleWidth(getDisplayName(a.display.type), layout.nameWidth);
       const modelThinking = padToVisibleWidth(this.displayModelThinking(a, layout.modelThinkingWidth), layout.modelThinkingWidth);
       const desc = padToVisibleWidth(this.displayDescription(a, layout.descriptionWidth), layout.descriptionWidth);
-      const header = `  ${theme.fg("muted", "◦")} ${theme.fg("dim", name)}${NAME_COLUMN_GAP}${this.renderModelThinkingColumn(modelThinking, theme, layout)}${theme.fg("dim", desc)}`;
+      const header = `  ${theme.fg(statusDisplay.color, statusDisplay.icon)} ${theme.fg("dim", name)}${NAME_COLUMN_GAP}${this.renderModelThinkingColumn(modelThinking, theme, layout)}${theme.fg("dim", desc)}`;
       blocks.push({ header: truncate(header), continuations: [] });
     }
     return blocks;
@@ -828,9 +832,11 @@ export class AgentWidget {
   }
 
   /** Update the status bar text, only if it changed. */
-  private updateStatusBar(runningCount: number, queuedCount: number, running: AgentRecord[]) {
-    const total = runningCount + queuedCount;
-    let statusText = total > 0 ? `${total} agent${total === 1 ? "" : "s"}` : `agents`;
+  private updateStatusBar(runningCount: number, queuedCount: number, finishedCount: number, running: AgentRecord[]) {
+    const activeCount = runningCount + queuedCount;
+    const activeText = activeCount > 0 ? `${activeCount} agent${activeCount === 1 ? "" : "s"}` : "";
+    const finishedText = finishedCount > 0 ? `${finishedCount} finished${finishedCount === 1 ? " agent" : " agents"}` : "";
+    let statusText = [activeText, finishedText].filter(Boolean).join(" · ");
     if (this.showCost) {
       const sessionCost = this.manager.getTotalAgentCost();
       // Also include in-flight running agents (not yet completed, so not in accumulator)
@@ -876,7 +882,7 @@ export class AgentWidget {
     }
 
     // Status bar — only call setStatus when the text actually changes
-    this.updateStatusBar(running.length, queued.length, running);
+    this.updateStatusBar(running.length, queued.length, finished.length, running);
 
     this.widgetFrame++;
 

--- a/src/ui/agent-widget.ts
+++ b/src/ui/agent-widget.ts
@@ -36,6 +36,7 @@ const NAME_COLUMN_GAP = "   ";
 const MODEL_THINKING_COLUMN_GAP = "    ";
 const ROW_PREFIX_WIDTH = 4; // two-space indent, status icon, and following space
 const STATS_COLUMN_GAP_WIDTH = 2;
+const STATS_GROUP_SEPARATOR = "  ";
 const ACTIVITY_COLUMN_GAP_WIDTH = 2;
 
 // ---- Types ----
@@ -495,11 +496,11 @@ export class AgentWidget {
       durationMs,
     }, theme, this.statsVisibility);
 
-    const statsLine = statsParts.join(" · ");
+    const statsLine = statsParts.join(STATS_GROUP_SEPARATOR);
     return `${icon} ${theme.fg("dim", name)}${NAME_COLUMN_GAP}${this.renderModelThinkingColumn(modelThinking, theme, layout)}${theme.fg("dim", description)}  ${wrapInDim(theme, statsLine)}${statusText}`;
   }
 
-  /** Build the stats line (toolUses · turns · tokens · cost · elapsed) for a running agent. */
+  /** Build the stats line (tool uses, turns, tokens, cost, elapsed) for a running agent. */
   private buildStatsLine(
     agent: AgentRecord,
     theme: Theme,
@@ -517,7 +518,7 @@ export class AgentWidget {
       ...this.usageSnapshot(agent),
       durationMs: Date.now() - agent.lifecycle.startedAt,
     }, theme, this.statsVisibility);
-    return fgPreservingNestedStyles(theme, "text", parts.join(" · "));
+    return fgPreservingNestedStyles(theme, "text", parts.join(STATS_GROUP_SEPARATOR));
   }
 
   /** Build RenderBlocks for finished (completed/errored) agents. */

--- a/src/ui/agent-widget.ts
+++ b/src/ui/agent-widget.ts
@@ -2,17 +2,13 @@
  * agent-widget.ts — Persistent widget showing running/completed agents above the editor.
  */
 
-import { truncateToWidth } from "@earendil-works/pi-tui";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { getSessionCtx } from "../shell.js";
 import type { AgentManager } from "../agents/agent-manager.js";
 import type { AgentRecord } from "../types.js";
 import type { Theme } from "./types.js";
-import {
-  formatCost,
-  getLifetimeTotal,
-  getSessionContextPercent,
-} from "../agents/usage.js";
-import { formatMs, buildStatsParts, getDisplayName, truncateDesc, describeActivity, type StatsVisibility } from "./format.js";
+import { formatCost, getSessionUsageSnapshot } from "../agents/usage.js";
+import { formatMs, buildStatsParts, formatThinkingTag, getDisplayName, truncateDesc, describeActivity, type StatsVisibility } from "./format.js";
 import type { LiveView } from "../spawn/spawn-coordinator.js";
 
 // Re-export Theme so existing consumers (searchable-select, result-viewer) don't break
@@ -35,6 +31,12 @@ const STATUS_KEY = "subagents";
 /** Widget refresh interval in milliseconds. */
 const WIDGET_REFRESH_INTERVAL = 80;
 
+/** Fixed horizontal gaps between the aligned agent columns. */
+const NAME_COLUMN_GAP = "   ";
+const MODEL_THINKING_COLUMN_GAP = "    ";
+const ROW_PREFIX_WIDTH = 4; // two-space indent, status icon, and following space
+const STATS_COLUMN_GAP_WIDTH = 2;
+const ACTIVITY_COLUMN_GAP_WIDTH = 2;
 
 // ---- Types ----
 
@@ -60,6 +62,13 @@ interface RenderBlock {
   continuations: string[];
 }
 
+/** Visible terminal column widths shared by agent rows in a single render pass. */
+interface AgentColumnLayout {
+  nameWidth: number;
+  modelThinkingWidth: number;
+  descriptionWidth: number;
+}
+
 // ---- Re-exports from format.ts (backward compatibility) ----
 export { formatMs, buildStatsParts, getDisplayName, type StatsVisibility } from "./format.js";
 export type { LiveView as AgentActivity } from "../spawn/spawn-coordinator.js";
@@ -78,6 +87,10 @@ function wrapInDim(theme: Theme, text: string): string {
   return dimOn + text.replaceAll(dimOff, dimOff + dimOn) + dimOff;
 }
 
+/** Pad an unstyled string to a target terminal width. */
+function padToVisibleWidth(text: string, width: number): string {
+  return text + " ".repeat(Math.max(0, width - visibleWidth(text)));
+}
 
 /** Build the worktree/output continuation line parts for an agent record. */
 function buildWorktreeOutputParts(a: AgentRecord): string[] {
@@ -367,10 +380,98 @@ export class AgentWidget {
     }
   }
 
+  /** Build the optional parenthesized model/thinking label for an agent. */
+  private modelThinkingLabel(a: AgentRecord): string {
+    const invocation = a.display.invocation;
+    const modelName = typeof invocation?.modelName === "string" && invocation.modelName.trim()
+      ? invocation.modelName.trim()
+      : undefined;
+    const thinkingTag = formatThinkingTag(invocation?.thinkingLevel);
+    const parts = [modelName, thinkingTag].filter((part): part is string => part !== undefined);
+    return parts.length > 0 ? `(${parts.join(" · ")})` : "";
+  }
+
+  /** Get an agent description at the display length and, when needed, terminal width. */
+  private displayDescription(a: AgentRecord, maxWidth?: number): string {
+    const description = truncateDesc(a.display.description, this.isCompact() ? this.descLengthCompact : this.descLengthFull);
+    return maxWidth == null ? description : truncateToWidth(description, maxWidth);
+  }
+
+  /** Get a model/thinking label at the available terminal width before applying styling. */
+  private displayModelThinking(a: AgentRecord, maxWidth?: number): string {
+    const label = this.modelThinkingLabel(a);
+    return maxWidth == null ? label : truncateToWidth(label, maxWidth);
+  }
+
+  /** Build shared terminal-width columns for visible individual agent rows. */
+  private buildAgentColumnLayout(agents: AgentRecord[], theme: Theme, terminalWidth: number): AgentColumnLayout {
+    const naturalLayout = agents.reduce<AgentColumnLayout>((layout, a) => ({
+      nameWidth: Math.max(layout.nameWidth, visibleWidth(getDisplayName(a.display.type))),
+      modelThinkingWidth: Math.max(layout.modelThinkingWidth, visibleWidth(this.displayModelThinking(a))),
+      descriptionWidth: Math.max(layout.descriptionWidth, visibleWidth(this.displayDescription(a))),
+    }), { nameWidth: 0, modelThinkingWidth: 0, descriptionWidth: 0 });
+    const statsWidth = Math.max(0, ...agents
+      .filter((a) => a.lifecycle.status !== "queued")
+      .map((a) => visibleWidth(this.buildStatsLine(a, theme))));
+    const activityWidth = this.isCompact()
+      ? Math.max(0, ...agents
+        .filter((a) => a.lifecycle.status === "running")
+        .map((a) => {
+          const live = this.getLiveView(a.id);
+          return visibleWidth(live ? describeActivity(live.activeTools, live.responseText) : "thinking…");
+        }))
+      : 0;
+    const reservedWidth = ROW_PREFIX_WIDTH
+      + naturalLayout.nameWidth
+      + visibleWidth(NAME_COLUMN_GAP)
+      + STATS_COLUMN_GAP_WIDTH
+      + statsWidth
+      + (this.isCompact() ? ACTIVITY_COLUMN_GAP_WIDTH + activityWidth : 0);
+    const modelThinkingWidth = naturalLayout.modelThinkingWidth > 0
+      ? Math.min(naturalLayout.modelThinkingWidth, Math.max(0, terminalWidth - reservedWidth - visibleWidth(MODEL_THINKING_COLUMN_GAP)))
+      : 0;
+    const modelColumnWidth = modelThinkingWidth > 0
+      ? modelThinkingWidth + visibleWidth(MODEL_THINKING_COLUMN_GAP)
+      : 0;
+
+    return {
+      ...naturalLayout,
+      modelThinkingWidth,
+      descriptionWidth: Math.min(naturalLayout.descriptionWidth, Math.max(0, terminalWidth - reservedWidth - modelColumnWidth)),
+    };
+  }
+
+  /** Render the optional, shared-width model/thinking column and its trailing gap. */
+  private renderModelThinkingColumn(
+    modelThinking: string,
+    theme: Theme,
+    layout: AgentColumnLayout,
+  ): string {
+    return layout.modelThinkingWidth > 0
+      ? `${theme.fg("dim", modelThinking)}${MODEL_THINKING_COLUMN_GAP}`
+      : "";
+  }
+
+  /** Return live context/auth values, or the terminal snapshot when appropriate. */
+  private usageSnapshot(agent: AgentRecord) {
+    const live = getSessionUsageSnapshot(agent.execution.session);
+    const persisted = {
+      contextPercent: agent.stats.contextPercent,
+      contextWindow: agent.stats.contextWindow,
+      autoCompactionEnabled: agent.stats.autoCompactionEnabled,
+      usingSubscription: agent.stats.usingSubscription,
+    };
+    const terminal = agent.lifecycle.completedAt != null;
+    return terminal
+      ? (persisted.contextPercent != null || persisted.contextWindow != null ? persisted : live)
+      : (live ?? persisted);
+  }
+
   /** Render a finished agent line. */
-  private renderFinishedLine(a: AgentRecord, theme: Theme): string {
-    const name = getDisplayName(a.display.type);
-    const fullDesc = truncateDesc(a.display.description, this.descLengthFull);
+  private renderFinishedLine(a: AgentRecord, theme: Theme, layout: AgentColumnLayout): string {
+    const name = padToVisibleWidth(getDisplayName(a.display.type), layout.nameWidth);
+    const modelThinking = padToVisibleWidth(this.displayModelThinking(a, layout.modelThinkingWidth), layout.modelThinkingWidth);
+    const description = padToVisibleWidth(this.displayDescription(a, layout.descriptionWidth), layout.descriptionWidth);
     const { icon, statusText } = this.finishedIconAndStatus(a.lifecycle.status, a.error, theme);
 
     const durationMs = (a.lifecycle.completedAt ?? Date.now()) - a.lifecycle.startedAt;
@@ -380,14 +481,16 @@ export class AgentWidget {
       maxTurns: a.stats.maxTurns,
       input: a.stats.lifetimeUsage.input,
       output: a.stats.lifetimeUsage.output,
-      contextPercent: a.stats.contextPercent ?? null,
-      compactions: a.stats.compactionCount,
+      cacheRead: a.stats.cacheRead,
+      cacheWrite: a.stats.lifetimeUsage.cacheWrite,
+      latestCacheHitRate: a.stats.latestCacheHitRate,
       cost: a.stats.lifetimeUsage.cost,
+      ...this.usageSnapshot(a),
       durationMs,
     }, theme, this.statsVisibility);
 
-    const statsLine = statsParts.join("·");
-    return `${icon} ${theme.fg("dim", name)}  ${theme.fg("dim", fullDesc)}  ${wrapInDim(theme, statsLine)}${statusText}`;
+    const statsLine = statsParts.join(" · ");
+    return `${icon} ${theme.fg("dim", name)}${NAME_COLUMN_GAP}${this.renderModelThinkingColumn(modelThinking, theme, layout)}${theme.fg("dim", description)}  ${wrapInDim(theme, statsLine)}${statusText}`;
   }
 
   /** Build the stats line (toolUses · turns · tokens · cost · elapsed) for a running agent. */
@@ -401,12 +504,14 @@ export class AgentWidget {
       maxTurns: agent.stats.maxTurns,
       input: agent.stats.lifetimeUsage.input,
       output: agent.stats.lifetimeUsage.output,
-      contextPercent: agent.execution.session ? getSessionContextPercent(agent.execution.session) : agent.stats.contextPercent ?? null,
-      compactions: agent.stats.compactionCount,
+      cacheRead: agent.stats.cacheRead,
+      cacheWrite: agent.stats.lifetimeUsage.cacheWrite,
+      latestCacheHitRate: agent.stats.latestCacheHitRate,
       cost: agent.stats.lifetimeUsage.cost,
+      ...this.usageSnapshot(agent),
       durationMs: Date.now() - agent.lifecycle.startedAt,
     }, theme, this.statsVisibility);
-    return parts.join("·");
+    return parts.join(" · ");
   }
 
   /** Build RenderBlocks for finished (completed/errored) agents. */
@@ -414,6 +519,7 @@ export class AgentWidget {
     finished: AgentRecord[],
     theme: Theme,
     w: number,
+    layout: AgentColumnLayout,
   ): RenderBlock[] {
     const truncate = (line: string) => truncateToWidth(line, w);
     const blocks: RenderBlock[] = [];
@@ -426,7 +532,7 @@ export class AgentWidget {
         }
       }
       blocks.push({
-        header: truncate(`  ${this.renderFinishedLine(a, theme)}`),
+        header: truncate(`  ${this.renderFinishedLine(a, theme, layout)}`),
         continuations,
       });
     }
@@ -439,27 +545,30 @@ export class AgentWidget {
     theme: Theme,
     w: number,
     frame: string,
+    layout: AgentColumnLayout,
   ): RenderBlock[] {
     const truncate = (line: string) => truncateToWidth(line, w);
     const blocks: RenderBlock[] = [];
     for (const a of running) {
-      const name = getDisplayName(a.display.type);
+      const name = padToVisibleWidth(getDisplayName(a.display.type), layout.nameWidth);
+      const modelThinking = padToVisibleWidth(this.displayModelThinking(a, layout.modelThinkingWidth), layout.modelThinkingWidth);
+      const modelThinkingColumn = this.renderModelThinkingColumn(modelThinking, theme, layout);
       const bg = this.getLiveView(a.id);
       const statsLine = this.buildStatsLine(a, theme);
       const activity = bg ? describeActivity(bg.activeTools, bg.responseText) : "thinking…";
 
       if (this.isCompact()) {
         // Compact: single line with activity inline, truncated description
-        const desc = truncateDesc(a.display.description, this.descLengthCompact);
-        const headerLine = `  ${theme.fg("accent", frame)} ${theme.bold(name)}  ${desc}  ${statsLine}  ${theme.fg("dim", activity)}`;
+        const desc = padToVisibleWidth(this.displayDescription(a, layout.descriptionWidth), layout.descriptionWidth);
+        const headerLine = `  ${theme.fg("accent", frame)} ${theme.bold(name)}${NAME_COLUMN_GAP}${modelThinkingColumn}${desc}  ${statsLine}  ${theme.fg("dim", activity)}`;
         blocks.push({
           header: truncate(headerLine),
           continuations: [],
         });
       } else {
         // Full: header + continuation lines
-        const fullDesc = truncateDesc(a.display.description, this.descLengthFull);
-        const headerLine = `  ${theme.fg("accent", frame)} ${theme.bold(name)}  ${fullDesc}  ${statsLine}`;
+        const description = padToVisibleWidth(this.displayDescription(a, layout.descriptionWidth), layout.descriptionWidth);
+        const headerLine = `  ${theme.fg("accent", frame)} ${theme.bold(name)}${NAME_COLUMN_GAP}${modelThinkingColumn}${description}  ${statsLine}`;
         const continuations: string[] = [];
         const parts = buildWorktreeOutputParts(a);
         if (parts.length > 0) {
@@ -513,13 +622,20 @@ export class AgentWidget {
     const frame = SPINNER[this.widgetFrame % SPINNER.length];
 
     // Build blocks — separate arrays so overflow logic can apply priority: running > queued > finished.
-    const finishedBlocks = this.buildFinishedBlocks(finished, theme, w);
-    const runningBlocks = this.buildRunningBlocks(running, theme, w, frame);
+    // Align all individually rendered agent rows. The aggregate queued row deliberately
+    // remains unchanged outside navigation mode.
+    const layout = this.buildAgentColumnLayout([
+      ...finished,
+      ...running,
+      ...(this.navActive ? queued : []),
+    ], theme, w);
+    const finishedBlocks = this.buildFinishedBlocks(finished, theme, w, layout);
+    const runningBlocks = this.buildRunningBlocks(running, theme, w, frame, layout);
 
     // Queued: individual rows during nav, aggregated block otherwise.
     let queuedBlocks: RenderBlock[];
     if (this.navActive) {
-      queuedBlocks = this.buildQueuedIndividualBlocks(queued, theme, w);
+      queuedBlocks = this.buildQueuedIndividualBlocks(queued, theme, w, layout);
     } else {
       const aggregated = this.buildQueuedBlock(queued, theme, w);
       queuedBlocks = aggregated ? [aggregated] : [];
@@ -579,13 +695,16 @@ export class AgentWidget {
   }
 
   /** Build individual RenderBlocks for each queued agent (used during navigation). */
-  private buildQueuedIndividualBlocks(queued: AgentRecord[], theme: Theme, w: number): RenderBlock[] {
+  private buildQueuedIndividualBlocks(
+    queued: AgentRecord[], theme: Theme, w: number, layout: AgentColumnLayout,
+  ): RenderBlock[] {
     const truncate = (line: string) => truncateToWidth(line, w);
     const blocks: RenderBlock[] = [];
     for (const a of queued) {
-      const name = getDisplayName(a.display.type);
-      const desc = truncateDesc(a.display.description, this.descLengthFull);
-      const header = `  ${theme.fg("muted", "◦")} ${theme.fg("dim", name)}  ${theme.fg("dim", desc)}`;
+      const name = padToVisibleWidth(getDisplayName(a.display.type), layout.nameWidth);
+      const modelThinking = padToVisibleWidth(this.displayModelThinking(a, layout.modelThinkingWidth), layout.modelThinkingWidth);
+      const desc = padToVisibleWidth(this.displayDescription(a, layout.descriptionWidth), layout.descriptionWidth);
+      const header = `  ${theme.fg("muted", "◦")} ${theme.fg("dim", name)}${NAME_COLUMN_GAP}${this.renderModelThinkingColumn(modelThinking, theme, layout)}${theme.fg("dim", desc)}`;
       blocks.push({ header: truncate(header), continuations: [] });
     }
     return blocks;

--- a/src/ui/agent-widget.ts
+++ b/src/ui/agent-widget.ts
@@ -8,7 +8,7 @@ import type { AgentManager } from "../agents/agent-manager.js";
 import type { AgentRecord, AgentStatus } from "../types.js";
 import type { Theme } from "./types.js";
 import { formatCost, getSessionUsageSnapshot } from "../agents/usage.js";
-import { formatMs, buildStatsParts, formatThinkingTag, getAgentStatusDisplay, getDisplayName, truncateDesc, describeActivity, fgPreservingNestedStyles, type StatsVisibility } from "./format.js";
+import { buildStatsCells, buildStatsLayout, formatStatsRow, formatThinkingTag, getAgentStatusDisplay, getDisplayName, truncateDesc, describeActivity, fgPreservingNestedStyles, type StatsCells, type StatsLayout, type StatsVisibility } from "./format.js";
 import type { LiveView } from "../spawn/spawn-coordinator.js";
 
 // Re-export Theme so existing consumers (searchable-select, result-viewer) don't break
@@ -32,11 +32,10 @@ const STATUS_KEY = "subagents";
 const WIDGET_REFRESH_INTERVAL = 80;
 
 /** Fixed horizontal gaps between the aligned agent columns. */
-const NAME_COLUMN_GAP = "   ";
-const MODEL_THINKING_COLUMN_GAP = "    ";
+const NAME_COLUMN_GAP = "  ";
+const MODEL_THINKING_COLUMN_GAP = "  ";
 const ROW_PREFIX_WIDTH = 4; // two-space indent, status icon, and following space
 const STATS_COLUMN_GAP_WIDTH = 2;
-const STATS_GROUP_SEPARATOR = "  ";
 const ACTIVITY_COLUMN_GAP_WIDTH = 2;
 
 // ---- Types ----
@@ -410,7 +409,7 @@ export class AgentWidget {
   }
 
   /** Build shared terminal-width columns for visible individual agent rows. */
-  private buildAgentColumnLayout(agents: AgentRecord[], theme: Theme, terminalWidth: number): AgentColumnLayout {
+  private buildAgentColumnLayout(agents: AgentRecord[], terminalWidth: number, statsLines: Map<string, string>): AgentColumnLayout {
     const naturalLayout = agents.reduce<AgentColumnLayout>((layout, a) => ({
       nameWidth: Math.max(layout.nameWidth, visibleWidth(getDisplayName(a.display.type))),
       modelThinkingWidth: Math.max(layout.modelThinkingWidth, visibleWidth(this.displayModelThinking(a))),
@@ -418,7 +417,7 @@ export class AgentWidget {
     }), { nameWidth: 0, modelThinkingWidth: 0, descriptionWidth: 0 });
     const statsWidth = Math.max(0, ...agents
       .filter((a) => a.lifecycle.status !== "queued")
-      .map((a) => visibleWidth(this.buildStatsLine(a, theme))));
+      .map((a) => visibleWidth(statsLines.get(a.id) ?? "")));
     const activityWidth = this.isCompact()
       ? Math.max(0, ...agents
         .filter((a) => a.lifecycle.status === "running")
@@ -474,38 +473,9 @@ export class AgentWidget {
       : (live ?? persisted);
   }
 
-  /** Render a finished agent line. */
-  private renderFinishedLine(a: AgentRecord, theme: Theme, layout: AgentColumnLayout): string {
-    const name = padToVisibleWidth(getDisplayName(a.display.type), layout.nameWidth);
-    const modelThinking = padToVisibleWidth(this.displayModelThinking(a, layout.modelThinkingWidth), layout.modelThinkingWidth);
-    const description = padToVisibleWidth(this.displayDescription(a, layout.descriptionWidth), layout.descriptionWidth);
-    const { icon, statusText } = this.finishedIconAndStatus(a.lifecycle.status, a.error, theme);
-
-    const durationMs = (a.lifecycle.completedAt ?? Date.now()) - a.lifecycle.startedAt;
-    const statsParts = buildStatsParts({
-      toolUses: a.stats.toolUses,
-      turnCount: a.stats.turnCount,
-      maxTurns: a.stats.maxTurns,
-      input: a.stats.lifetimeUsage.input,
-      output: a.stats.lifetimeUsage.output,
-      cacheRead: a.stats.cacheRead,
-      cacheWrite: a.stats.lifetimeUsage.cacheWrite,
-      latestCacheHitRate: a.stats.latestCacheHitRate,
-      cost: a.stats.lifetimeUsage.cost,
-      ...this.usageSnapshot(a),
-      durationMs,
-    }, theme, this.statsVisibility);
-
-    const statsLine = statsParts.join(STATS_GROUP_SEPARATOR);
-    return `${icon} ${theme.fg("dim", name)}${NAME_COLUMN_GAP}${this.renderModelThinkingColumn(modelThinking, theme, layout)}${theme.fg("dim", description)}  ${wrapInDim(theme, statsLine)}${statusText}`;
-  }
-
-  /** Build the stats line (tool uses, turns, tokens, cost, elapsed) for a running agent. */
-  private buildStatsLine(
-    agent: AgentRecord,
-    theme: Theme,
-  ): string {
-    const parts = buildStatsParts({
+  /** Build structured stats for a running or finished agent. */
+  private buildStatsCells(agent: AgentRecord, theme: Theme): StatsCells {
+    return buildStatsCells({
       toolUses: agent.stats.toolUses,
       turnCount: agent.stats.turnCount,
       maxTurns: agent.stats.maxTurns,
@@ -516,9 +486,22 @@ export class AgentWidget {
       latestCacheHitRate: agent.stats.latestCacheHitRate,
       cost: agent.stats.lifetimeUsage.cost,
       ...this.usageSnapshot(agent),
-      durationMs: Date.now() - agent.lifecycle.startedAt,
+      durationMs: (agent.lifecycle.completedAt ?? Date.now()) - agent.lifecycle.startedAt,
     }, theme, this.statsVisibility);
-    return fgPreservingNestedStyles(theme, "text", parts.join(STATS_GROUP_SEPARATOR));
+  }
+
+  /** Render a structured stats row while preserving nested warning/error colors. */
+  private buildStatsLine(agent: AgentRecord, theme: Theme, statsLayout?: StatsLayout, cells?: StatsCells): string {
+    return fgPreservingNestedStyles(theme, "text", formatStatsRow(cells ?? this.buildStatsCells(agent, theme), statsLayout) ?? "");
+  }
+
+  /** Render a finished agent line. */
+  private renderFinishedLine(a: AgentRecord, theme: Theme, layout: AgentColumnLayout, rawStats: string): string {
+    const name = padToVisibleWidth(getDisplayName(a.display.type), layout.nameWidth);
+    const modelThinking = padToVisibleWidth(this.displayModelThinking(a, layout.modelThinkingWidth), layout.modelThinkingWidth);
+    const description = padToVisibleWidth(this.displayDescription(a, layout.descriptionWidth), layout.descriptionWidth);
+    const { icon, statusText } = this.finishedIconAndStatus(a.lifecycle.status, a.error, theme);
+    return `${icon} ${theme.fg("dim", name)}${NAME_COLUMN_GAP}${this.renderModelThinkingColumn(modelThinking, theme, layout)}${theme.fg("dim", description)}  ${wrapInDim(theme, rawStats)}${statusText}`;
   }
 
   /** Build RenderBlocks for finished (completed/errored) agents. */
@@ -527,6 +510,7 @@ export class AgentWidget {
     theme: Theme,
     w: number,
     layout: AgentColumnLayout,
+    statsLines: Map<string, string>,
   ): RenderBlock[] {
     const truncate = (line: string) => truncateToWidth(line, w);
     const blocks: RenderBlock[] = [];
@@ -539,7 +523,7 @@ export class AgentWidget {
         }
       }
       blocks.push({
-        header: truncate(`  ${this.renderFinishedLine(a, theme, layout)}`),
+        header: truncate(`  ${this.renderFinishedLine(a, theme, layout, statsLines.get(a.id) ?? "")}`),
         continuations,
       });
     }
@@ -553,6 +537,7 @@ export class AgentWidget {
     w: number,
     frame: string,
     layout: AgentColumnLayout,
+    statsLines: Map<string, string>,
   ): RenderBlock[] {
     const truncate = (line: string) => truncateToWidth(line, w);
     const blocks: RenderBlock[] = [];
@@ -561,7 +546,8 @@ export class AgentWidget {
       const modelThinking = padToVisibleWidth(this.displayModelThinking(a, layout.modelThinkingWidth), layout.modelThinkingWidth);
       const modelThinkingColumn = this.renderModelThinkingColumn(modelThinking, theme, layout, "text");
       const bg = this.getLiveView(a.id);
-      const statsLine = this.buildStatsLine(a, theme);
+      const rawStats = statsLines.get(a.id) ?? "";
+      const statsLine = fgPreservingNestedStyles(theme, "text", rawStats);
       const activity = bg ? describeActivity(bg.activeTools, bg.responseText) : "thinking…";
 
       if (this.isCompact()) {
@@ -629,15 +615,22 @@ export class AgentWidget {
     const frame = SPINNER[this.widgetFrame % SPINNER.length];
 
     // Build blocks — separate arrays so rendering and overflow use the same priority:
-    // running → queued → finished. Align all individually rendered agent rows. The
-    // aggregate queued row deliberately remains unchanged outside navigation mode.
+    // running → queued → finished. Running and completed rows share one stats
+    // layout; queued rows deliberately have no stats.
+    const statCells = new Map<string, StatsCells>();
+    for (const agent of [...running, ...finished]) statCells.set(agent.id, this.buildStatsCells(agent, theme));
+    const statsLayout = buildStatsLayout([...statCells.values()]);
+    const statsLines = new Map<string, string>();
+    for (const agent of [...running, ...finished]) {
+      statsLines.set(agent.id, formatStatsRow(statCells.get(agent.id)!, statsLayout) ?? "");
+    }
     const layout = this.buildAgentColumnLayout([
       ...running,
       ...(this.navActive ? queued : []),
       ...finished,
-    ], theme, w);
-    const finishedBlocks = this.buildFinishedBlocks(finished, theme, w, layout);
-    const runningBlocks = this.buildRunningBlocks(running, theme, w, frame, layout);
+    ], w, statsLines);
+    const finishedBlocks = this.buildFinishedBlocks(finished, theme, w, layout, statsLines);
+    const runningBlocks = this.buildRunningBlocks(running, theme, w, frame, layout, statsLines);
 
     // Queued: individual rows during nav, aggregated block otherwise.
     let queuedBlocks: RenderBlock[];

--- a/src/ui/conversation-viewer.ts
+++ b/src/ui/conversation-viewer.ts
@@ -15,7 +15,8 @@ import type { Theme } from "./types.js";
 import { makeMarkdownTheme } from "./markdown-theme.js";
 import {
   buildInvocationTags,
-  buildStatsParts,
+  buildStatsCells,
+  formatStatsRow,
   describeActivity,
   fgPreservingNestedStyles,
   getAgentStatusDisplay,
@@ -251,7 +252,7 @@ export class ConversationViewer implements Component {
       && (persistedSnapshot.contextPercent != null || persistedSnapshot.contextWindow != null)
       ? persistedSnapshot
       : (liveSnapshot ?? persistedSnapshot);
-    const statsParts = buildStatsParts({
+    const statsCells = buildStatsCells({
       toolUses: this.record.stats.toolUses,
       turnCount: this.record.stats.turnCount,
       maxTurns: this.record.stats.maxTurns,
@@ -273,7 +274,7 @@ export class ConversationViewer implements Component {
 
     // Row 2: model name + compact usage stats
     const { modelName, thinkingTag, tags } = buildInvocationTags(this.record.display.invocation);
-    const statsLine = fgPreservingNestedStyles(th, "dim", statsParts.join("  "));
+    const statsLine = fgPreservingNestedStyles(th, "dim", formatStatsRow(statsCells) ?? "");
     if (modelName) {
       const parts = [thinkingTag, statsLine, ...tags].filter(Boolean);
       lines.push(row(th.fg("dim", `  ${modelName} · ${parts.join(" · ")}`)));

--- a/src/ui/conversation-viewer.ts
+++ b/src/ui/conversation-viewer.ts
@@ -9,7 +9,7 @@
 import type { AgentSession } from "@earendil-works/pi-coding-agent";
 import { type Component, Input, Markdown, matchesKey, type TUI, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import type { AgentRecord, AgentStatus } from "../types.js";
-import { getSessionContextPercent } from "../agents/usage.js";
+import { getSessionUsageSnapshot } from "../agents/usage.js";
 import { extractText } from "../prompt/context.js";
 import type { Theme } from "./types.js";
 import { makeMarkdownTheme } from "./markdown-theme.js";
@@ -244,17 +244,31 @@ export class ConversationViewer implements Component {
     const status = this.record.lifecycle.status;
     const { icon, color } = STATUS_ICON[status];
     const statusIcon = th.fg(color, icon);
-    // Build stats line like the widget
+    // Build stats line like the widget, retaining the final snapshot after a
+    // completed session has no longer-live context information.
     const durationMs = (this.record.lifecycle.completedAt ?? Date.now()) - this.record.lifecycle.startedAt;
+    const liveSnapshot = getSessionUsageSnapshot(this.session);
+    const persistedSnapshot = {
+      contextPercent: this.record.stats.contextPercent,
+      contextWindow: this.record.stats.contextWindow,
+      autoCompactionEnabled: this.record.stats.autoCompactionEnabled,
+      usingSubscription: this.record.stats.usingSubscription,
+    };
+    const usageSnapshot = this.record.lifecycle.completedAt != null
+      && (persistedSnapshot.contextPercent != null || persistedSnapshot.contextWindow != null)
+      ? persistedSnapshot
+      : (liveSnapshot ?? persistedSnapshot);
     const statsParts = buildStatsParts({
       toolUses: this.record.stats.toolUses,
       turnCount: this.record.stats.turnCount,
       maxTurns: this.record.stats.maxTurns,
       input: this.record.stats.lifetimeUsage.input,
       output: this.record.stats.lifetimeUsage.output,
-      contextPercent: getSessionContextPercent(this.session),
-      compactions: this.record.stats.compactionCount,
+      cacheRead: this.record.stats.cacheRead,
+      cacheWrite: this.record.stats.lifetimeUsage.cacheWrite,
+      latestCacheHitRate: this.record.stats.latestCacheHitRate,
       cost: this.record.stats.lifetimeUsage.cost,
+      ...usageSnapshot,
       durationMs,
     }, th);
 
@@ -265,13 +279,14 @@ export class ConversationViewer implements Component {
     ));
 
     // Row 2: model name + compact usage stats
-    const { modelName, tags } = buildInvocationTags(this.record.display.invocation);
-    const statsLine = fgPreservingNestedStyles(th, "dim", statsParts.join("·"));
+    const { modelName, thinkingTag, tags } = buildInvocationTags(this.record.display.invocation);
+    const statsLine = fgPreservingNestedStyles(th, "dim", statsParts.join(" · "));
     if (modelName) {
-      const parts = [statsLine, ...tags].filter(Boolean);
+      const parts = [thinkingTag, statsLine, ...tags].filter(Boolean);
       lines.push(row(th.fg("dim", `  ${modelName} · ${parts.join(" · ")}`)));
     } else {
-      lines.push(row(statsLine));
+      const parts = [thinkingTag, statsLine].filter(Boolean);
+      lines.push(row(parts.join(" · ")));
     }
     lines.push(hrMid);
 

--- a/src/ui/conversation-viewer.ts
+++ b/src/ui/conversation-viewer.ts
@@ -8,7 +8,7 @@
 
 import type { AgentSession } from "@earendil-works/pi-coding-agent";
 import { type Component, Input, Markdown, matchesKey, type TUI, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
-import type { AgentRecord, AgentStatus } from "../types.js";
+import type { AgentRecord } from "../types.js";
 import { getSessionUsageSnapshot } from "../agents/usage.js";
 import { extractText } from "../prompt/context.js";
 import type { Theme } from "./types.js";
@@ -18,8 +18,10 @@ import {
   buildStatsParts,
   describeActivity,
   fgPreservingNestedStyles,
+  getAgentStatusDisplay,
   getDisplayName,
   summarizeToolArgs,
+  type StatsVisibility,
 } from "./format.js";
 import { createViewerKeys, type ViewerKeybindings, type ViewerKeys } from "./viewer-keys.js";
 
@@ -34,17 +36,6 @@ const TOOL_RESULT_MAX_CHARS = 500;
 const TOOL_RESULT_MAX_LINES = 5;
 /** Debounce interval for streaming renders — reduces CPU during fast token arrival. */
 const STREAM_RENDER_DEBOUNCE_MS = 100;
-
-/** Header status icon and its theme color, per lifecycle status. */
-const STATUS_ICON: Record<AgentStatus, { icon: string; color: "accent" | "success" | "warning" | "error" | "dim" }> = {
-  running: { icon: "◈", color: "accent" },
-  completed: { icon: "✓", color: "success" },
-  turn_limited: { icon: "✓", color: "warning" },
-  error: { icon: "✗", color: "error" },
-  aborted: { icon: "✗", color: "error" },
-  stopped: { icon: "✗", color: "error" },
-  queued: { icon: "◇", color: "dim" },
-};
 
 export class ConversationViewer implements Component {
   private scrollOffset = 0;
@@ -89,6 +80,8 @@ export class ConversationViewer implements Component {
     keybindings?: ViewerKeybindings,
     /** Send a steering message to the agent. Omitted -> no compose affordance. */
     private onSteer?: (message: string) => void,
+    /** Configured visibility of the shared usage statistics. */
+    private statsVisibility?: StatsVisibility,
   ) {
     this.keys = createViewerKeys(keybindings);
     this.unsubscribe = session.subscribe((event) => {
@@ -242,7 +235,7 @@ export class ConversationViewer implements Component {
     const name = getDisplayName(this.record.display.type);
 
     const status = this.record.lifecycle.status;
-    const { icon, color } = STATUS_ICON[status];
+    const { icon, color } = getAgentStatusDisplay(status);
     const statusIcon = th.fg(color, icon);
     // Build stats line like the widget, retaining the final snapshot after a
     // completed session has no longer-live context information.
@@ -270,7 +263,7 @@ export class ConversationViewer implements Component {
       cost: this.record.stats.lifetimeUsage.cost,
       ...usageSnapshot,
       durationMs,
-    }, th);
+    }, th, this.statsVisibility);
 
     const worktreeTag = this.record.display.worktreeLabel ? th.fg("muted", ` @${this.record.display.worktreeLabel}`) : "";
     // Row 1: status icon, name, description, worktree

--- a/src/ui/conversation-viewer.ts
+++ b/src/ui/conversation-viewer.ts
@@ -273,7 +273,7 @@ export class ConversationViewer implements Component {
 
     // Row 2: model name + compact usage stats
     const { modelName, thinkingTag, tags } = buildInvocationTags(this.record.display.invocation);
-    const statsLine = fgPreservingNestedStyles(th, "dim", statsParts.join(" · "));
+    const statsLine = fgPreservingNestedStyles(th, "dim", statsParts.join("  "));
     if (modelName) {
       const parts = [thinkingTag, statsLine, ...tags].filter(Boolean);
       lines.push(row(th.fg("dim", `  ${modelName} · ${parts.join(" · ")}`)));

--- a/src/ui/format.ts
+++ b/src/ui/format.ts
@@ -14,6 +14,7 @@ import type { AgentStatus } from "../types.js";
 import type { Theme } from "./types.js";
 import { formatTokens, formatCost } from "../agents/usage.js";
 import { parseThinkingLevel } from "../utils.js";
+import { visibleWidth } from "@earendil-works/pi-tui";
 
 /** Truncate a description string to `maxLen` characters, appending "..." if truncated. */
 export function truncateDesc(text: string, maxLen: number): string {
@@ -42,34 +43,141 @@ export interface UsageDisplay {
   autoCompactionEnabled?: boolean;
 }
 
+/** Individually addressable fields in the shared agent statistics display. */
+export interface StatsCells {
+  tools?: string;
+  turns?: string;
+  input?: string;
+  output?: string;
+  cacheRead?: string;
+  cacheWrite?: string;
+  hitRate?: string;
+  cost?: string;
+  context?: string;
+  duration?: string;
+}
+
+type UsageCellName = "input" | "output" | "cacheRead" | "cacheWrite" | "hitRate" | "cost" | "context";
+const USAGE_CELL_NAMES: UsageCellName[] = ["input", "output", "cacheRead", "cacheWrite", "hitRate", "cost", "context"];
+const PLAIN_THEME: Theme = {
+  fg: (_color, text) => text,
+  bg: (_color, text) => text,
+  bold: (text) => text,
+};
+
 /**
- * Format the exact Pi footer usage sequence. This intentionally keeps one
- * contiguous group: callers may put tools, turns, and duration around it using
- * their quieter ` · ` separators without splitting its space-separated fields.
+ * Build individually addressable agent stat cells. Keeping Pi footer fields
+ * separate lets multi-agent displays align each metric without changing the
+ * established single-row Pi sequence.
  */
-export function formatUsageBlock(args: UsageDisplay, visible?: StatsVisibility, theme?: Theme): string | undefined {
-  const parts: string[] = [];
-  if (visible?.showInput !== false && args.input > 0) parts.push(`↑${formatTokens(args.input)}`);
-  if (visible?.showOutput !== false && args.output > 0) parts.push(`↓${formatTokens(args.output)}`);
+export function buildStatsCells(
+  args: UsageDisplay & {
+    toolUses: number;
+    turnCount?: number;
+    maxTurns?: number;
+    durationMs?: number;
+  },
+  theme: Theme,
+  visible?: StatsVisibility,
+): StatsCells {
+  const cells: StatsCells = {};
+  if (visible?.showTools !== false && args.toolUses > 0) cells.tools = `${args.toolUses}⚙︎`;
+  if (visible?.showTurns !== false && args.turnCount != null) cells.turns = formatTurns(args.turnCount, args.maxTurns, theme);
+  if (visible?.showInput !== false && args.input > 0) cells.input = `↑${formatTokens(args.input)}`;
+  if (visible?.showOutput !== false && args.output > 0) cells.output = `↓${formatTokens(args.output)}`;
   if (visible?.showInput !== false) {
-    if ((args.cacheRead ?? 0) > 0) parts.push(`R${formatTokens(args.cacheRead!)}`);
-    if ((args.cacheWrite ?? 0) > 0) parts.push(`W${formatTokens(args.cacheWrite!)}`);
+    if ((args.cacheRead ?? 0) > 0) cells.cacheRead = `R${formatTokens(args.cacheRead!)}`;
+    if ((args.cacheWrite ?? 0) > 0) cells.cacheWrite = `W${formatTokens(args.cacheWrite!)}`;
     if (((args.cacheRead ?? 0) > 0 || (args.cacheWrite ?? 0) > 0) && args.latestCacheHitRate != null) {
-      parts.push(`CH${args.latestCacheHitRate.toFixed(1)}%`);
+      cells.hitRate = `CH${args.latestCacheHitRate.toFixed(1)}%`;
     }
   }
-  if (visible?.showCost !== false && (args.cost != null && (args.cost > 0 || args.usingSubscription))) {
-    parts.push(`${formatCost(args.cost)}${args.usingSubscription ? " (sub)" : ""}`);
+  if (visible?.showCost !== false && args.cost != null && (args.cost > 0 || args.usingSubscription)) {
+    cells.cost = `${formatCost(args.cost)}${args.usingSubscription ? " (sub)" : ""}`;
   }
   if (visible?.showContext !== false && (args.contextPercent != null || args.contextWindow != null)) {
     const context = args.contextPercent == null ? "?" : `${args.contextPercent.toFixed(1)}%`;
-    const contextDisplay = `${context}/${formatTokens(args.contextWindow ?? 0)}${args.autoCompactionEnabled ? " (auto)" : ""}`;
-    const contextColor = args.contextPercent != null && args.contextPercent > 90
+    const display = `${context}/${formatTokens(args.contextWindow ?? 0)}${args.autoCompactionEnabled ? " (auto)" : ""}`;
+    const color = args.contextPercent != null && args.contextPercent > 90
       ? "error"
       : args.contextPercent != null && args.contextPercent > 70 ? "warning" : undefined;
-    parts.push(contextColor && theme ? theme.fg(contextColor, contextDisplay) : contextDisplay);
+    cells.context = color ? theme.fg(color, display) : display;
   }
+  if (visible?.showTime !== false && args.durationMs != null) cells.duration = formatMs(args.durationMs);
+  return cells;
+}
+
+/** Format the exact contiguous Pi footer usage sequence. */
+export function formatUsageBlock(args: UsageDisplay, visible?: StatsVisibility, theme?: Theme): string | undefined {
+  // The usage cells do not need turn styling; use the supplied theme only for
+  // Pi's warning/error context foreground when one is available.
+  const cells = buildStatsCells({ ...args, toolUses: 0 }, theme ?? PLAIN_THEME, visible);
+  const parts = USAGE_CELL_NAMES.map((name) => cells[name]).filter((part): part is string => part !== undefined);
   return parts.length > 0 ? parts.join(" ") : undefined;
+}
+
+/** Shared widths for a set of widget stat rows. */
+export interface StatsLayout {
+  hasCounters: boolean;
+  hasUsage: boolean;
+  toolWidth: number;
+  turnWidth: number;
+  usageWidths: Record<UsageCellName, number>;
+}
+
+/** Compute ANSI- and wide-character-aware widths for aligned stat rows. */
+export function buildStatsLayout(rows: StatsCells[]): StatsLayout {
+  const usageWidths = Object.fromEntries(USAGE_CELL_NAMES.map((name) => [name, 0])) as Record<UsageCellName, number>;
+  let toolWidth = 0;
+  let turnWidth = 0;
+  for (const row of rows) {
+    toolWidth = Math.max(toolWidth, visibleWidth(row.tools ?? ""));
+    turnWidth = Math.max(turnWidth, visibleWidth(row.turns ?? ""));
+    for (const name of USAGE_CELL_NAMES) usageWidths[name] = Math.max(usageWidths[name], visibleWidth(row[name] ?? ""));
+  }
+  return {
+    hasCounters: toolWidth > 0 || turnWidth > 0,
+    hasUsage: USAGE_CELL_NAMES.some((name) => usageWidths[name] > 0),
+    toolWidth,
+    turnWidth,
+    usageWidths,
+  };
+}
+
+function padStatsCell(text: string | undefined, width: number, rightAlign = false): string {
+  const padding = " ".repeat(Math.max(0, width - visibleWidth(text ?? "")));
+  return rightAlign ? padding + (text ?? "") : (text ?? "") + padding;
+}
+
+/**
+ * Render one structured stats row. Without a layout this is the compact,
+ * single-row form. With one, counter cells are right-aligned and Pi cells are
+ * padded by metric so the following duration column has a shared start.
+ */
+export function formatStatsRow(cells: StatsCells, layout?: StatsLayout): string | undefined {
+  if (!layout) {
+    const counters = [cells.tools, cells.turns].filter((cell): cell is string => cell !== undefined).join("  ");
+    const usage = USAGE_CELL_NAMES.map((name) => cells[name]).filter((cell): cell is string => cell !== undefined).join(" ");
+    const groups = [counters, usage, cells.duration].filter((group): group is string => group !== undefined && group.length > 0);
+    return groups.length > 0 ? groups.join(" · ") : undefined;
+  }
+
+  const groups: string[] = [];
+  if (layout.hasCounters) {
+    const counters = layout.toolWidth > 0 && layout.turnWidth > 0
+      ? `${padStatsCell(cells.tools, layout.toolWidth, true)}  ${padStatsCell(cells.turns, layout.turnWidth, true)}`
+      : layout.toolWidth > 0 ? padStatsCell(cells.tools, layout.toolWidth, true) : padStatsCell(cells.turns, layout.turnWidth, true);
+    groups.push(counters);
+  }
+  if (layout.hasUsage) {
+    const usage = USAGE_CELL_NAMES
+      .filter((name) => layout.usageWidths[name] > 0)
+      .map((name) => padStatsCell(cells[name], layout.usageWidths[name]))
+      .join(" ");
+    groups.push(usage);
+  }
+  if (cells.duration !== undefined) groups.push(cells.duration);
+  return groups.length > 0 ? groups.join(" · ") : undefined;
 }
 
 /** Format turn count with optional max limit. Shows max when >= 80% of limit. */
@@ -126,12 +234,13 @@ export function buildStatsParts(
   theme: Theme,
   visible?: StatsVisibility,
 ): string[] {
+  const cells = buildStatsCells(args, theme, visible);
   const parts: string[] = [];
-  if (visible?.showTools !== false && args.toolUses > 0) parts.push(`${args.toolUses}⚙︎`);
-  if (visible?.showTurns !== false && args.turnCount != null) parts.push(formatTurns(args.turnCount, args.maxTurns, theme));
-  const usage = formatUsageBlock(args, visible, theme);
+  if (cells.tools) parts.push(cells.tools);
+  if (cells.turns) parts.push(cells.turns);
+  const usage = USAGE_CELL_NAMES.map((name) => cells[name]).filter((part): part is string => part !== undefined).join(" ");
   if (usage) parts.push(usage);
-  if (visible?.showTime !== false && args.durationMs != null) parts.push(formatMs(args.durationMs));
+  if (cells.duration) parts.push(cells.duration);
   return parts;
 }
 

--- a/src/ui/format.ts
+++ b/src/ui/format.ts
@@ -10,6 +10,7 @@
 
 import { getConfig } from "../agents/agent-types.js";
 import type { SubagentType, AgentInvocation } from "../agents/types.js";
+import type { AgentStatus } from "../types.js";
 import type { Theme } from "./types.js";
 import { formatTokens, formatCost } from "../agents/usage.js";
 import { parseThinkingLevel } from "../utils.js";
@@ -137,6 +138,25 @@ export function buildStatsParts(
 /** Get display name for any agent type (built-in or custom). */
 export function getDisplayName(type: SubagentType): string {
   return getConfig(type).displayName;
+}
+
+/** Shared lifecycle icon and color used by agent views. */
+export function getAgentStatusDisplay(status: AgentStatus): { icon: string; color: string } {
+  switch (status) {
+    case "running":
+      return { icon: "◈", color: "accent" };
+    case "queued":
+      return { icon: "◇", color: "dim" };
+    case "completed":
+      return { icon: "✓", color: "success" };
+    case "turn_limited":
+      return { icon: "✓", color: "warning" };
+    case "stopped":
+      return { icon: "■", color: "dim" };
+    case "error":
+    case "aborted":
+      return { icon: "✗", color: "error" };
+  }
 }
 
 /**

--- a/src/ui/format.ts
+++ b/src/ui/format.ts
@@ -283,7 +283,7 @@ export function formatDuration(startedAt: number, completedAt?: number): string 
 /** Format a concrete thinking level for display; omitted or inherited values have no tag. */
 export function formatThinkingTag(value: unknown): string | undefined {
   const thinkingLevel = typeof value === "string" ? parseThinkingLevel(value) : undefined;
-  return thinkingLevel ? `thinking: ${thinkingLevel}` : undefined;
+  return thinkingLevel;
 }
 
 /** Build invocation display tags from an AgentInvocation. */

--- a/src/ui/format.ts
+++ b/src/ui/format.ts
@@ -126,7 +126,7 @@ export function buildStatsParts(
   visible?: StatsVisibility,
 ): string[] {
   const parts: string[] = [];
-  if (visible?.showTools !== false && args.toolUses > 0) parts.push(`${args.toolUses}🛠`);
+  if (visible?.showTools !== false && args.toolUses > 0) parts.push(`${args.toolUses}⚙︎`);
   if (visible?.showTurns !== false && args.turnCount != null) parts.push(formatTurns(args.turnCount, args.maxTurns, theme));
   const usage = formatUsageBlock(args, visible, theme);
   if (usage) parts.push(usage);

--- a/src/ui/format.ts
+++ b/src/ui/format.ts
@@ -12,6 +12,7 @@ import { getConfig } from "../agents/agent-types.js";
 import type { SubagentType, AgentInvocation } from "../agents/types.js";
 import type { Theme } from "./types.js";
 import { formatTokens, formatCost } from "../agents/usage.js";
+import { parseThinkingLevel } from "../utils.js";
 
 /** Truncate a description string to `maxLen` characters, appending "..." if truncated. */
 export function truncateDesc(text: string, maxLen: number): string {
@@ -24,46 +25,57 @@ const MAX_COMMAND_DISPLAY_LENGTH = 350;
 /** Max length for a truncated string value in default tool arg summaries. */
 const MAX_DEFAULT_STRING_DISPLAY_LENGTH = 350;
 
-// ---- Internal helpers (used by buildStatsParts) ----
+// ---- Usage formatting -----------------------------------------------------
+
+/** Fields for Pi's contiguous usage block. */
+export interface UsageDisplay {
+  input: number;
+  output: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  latestCacheHitRate?: number;
+  cost?: number;
+  usingSubscription?: boolean;
+  contextPercent?: number | null;
+  contextWindow?: number;
+  autoCompactionEnabled?: boolean;
+}
 
 /**
- * Token count with optional context-fill % and compaction-count annotations.
- * Thresholds for percent: <70% dim, 70–85% warning, ≥85% error.
- * Compaction count rendered as `↻ N` in dim.
- *
- *   "↑12k↓8k"                    — no annotations
- *   "↑12k↓8k 45%"                — percent only
- *   "↑12k↓8k ↻ 2"                 — compactions only (e.g. right after compact)
- *   "↑12k↓8k 45% ↻ 2"             — both
+ * Format the exact Pi footer usage sequence. This intentionally keeps one
+ * contiguous group: callers may put tools, turns, and duration around it using
+ * their quieter ` · ` separators without splitting its space-separated fields.
  */
-export function formatSessionTokens(
-  inputTokens: number,
-  outputTokens: number,
-  percent: number | null,
-  theme: Theme,
-  compactions = 0,
-): string {
-  const tokenParts: string[] = [];
-  if (inputTokens > 0) tokenParts.push(`↑${formatTokens(inputTokens, true)}`);
-  if (outputTokens > 0) tokenParts.push(`↓${formatTokens(outputTokens, true)}`);
-  const tokenStr = tokenParts.join("");
-  const annot: string[] = [];
-  if (percent !== null) {
-    const color = percent >= 85 ? "error" : percent >= 70 ? "warning" : "dim";
-    annot.push(theme.fg(color, `${Math.round(percent)}%`));
+export function formatUsageBlock(args: UsageDisplay, visible?: StatsVisibility, theme?: Theme): string | undefined {
+  const parts: string[] = [];
+  if (visible?.showInput !== false && args.input > 0) parts.push(`↑${formatTokens(args.input)}`);
+  if (visible?.showOutput !== false && args.output > 0) parts.push(`↓${formatTokens(args.output)}`);
+  if (visible?.showInput !== false) {
+    if ((args.cacheRead ?? 0) > 0) parts.push(`R${formatTokens(args.cacheRead!)}`);
+    if ((args.cacheWrite ?? 0) > 0) parts.push(`W${formatTokens(args.cacheWrite!)}`);
+    if (((args.cacheRead ?? 0) > 0 || (args.cacheWrite ?? 0) > 0) && args.latestCacheHitRate != null) {
+      parts.push(`CH${args.latestCacheHitRate.toFixed(1)}%`);
+    }
   }
-  if (compactions > 0) {
-    annot.push(theme.fg("dim", `↻ ${compactions}`));
+  if (visible?.showCost !== false && (args.cost != null && (args.cost > 0 || args.usingSubscription))) {
+    parts.push(`${formatCost(args.cost)}${args.usingSubscription ? " (sub)" : ""}`);
   }
-  if (annot.length === 0) return tokenStr;
-  return `${tokenStr} ${annot.join(" ")}`;
+  if (visible?.showContext !== false && (args.contextPercent != null || args.contextWindow != null)) {
+    const context = args.contextPercent == null ? "?" : `${args.contextPercent.toFixed(1)}%`;
+    const contextDisplay = `${context}/${formatTokens(args.contextWindow ?? 0)}${args.autoCompactionEnabled ? " (auto)" : ""}`;
+    const contextColor = args.contextPercent != null && args.contextPercent > 90
+      ? "error"
+      : args.contextPercent != null && args.contextPercent > 70 ? "warning" : undefined;
+    parts.push(contextColor && theme ? theme.fg(contextColor, contextDisplay) : contextDisplay);
+  }
+  return parts.length > 0 ? parts.join(" ") : undefined;
 }
 
 /** Format turn count with optional max limit. Shows max when >= 80% of limit. */
 function formatTurns(turnCount: number, maxTurns: number | null | undefined, theme: Theme): string {
-  if (maxTurns == null) return `${turnCount}⟳ `;
+  if (maxTurns == null) return `${turnCount}⟳`;
   const ratio = turnCount / maxTurns;
-  const text = ratio >= 0.8 ? `${turnCount}≤${maxTurns}⟳ ` : `${turnCount}⟳ `;
+  const text = ratio >= 0.8 ? `${turnCount}≤${maxTurns}⟳` : `${turnCount}⟳`;
   if (ratio >= 1) return theme.fg("error", text);
   if (ratio >= 0.8) return theme.fg("warning", text);
   return text;
@@ -100,45 +112,24 @@ export interface StatsVisibility {
 }
 
 /**
- * Build common stats parts: toolUses · turns · input↓ output with context % · cost · time.
- * Shared by AgentWidget and index.ts for consistent stats display.
- *
- * @param visible - Optional visibility flags. All default to true for backward compatibility.
- * @param durationMs - Optional duration in ms. When provided and showTime is not false, appends formatted time.
+ * Build common stats groups. Tools, turns, Pi usage, and duration are kept
+ * separate so every caller can join the groups with ` · ` consistently.
  */
 export function buildStatsParts(
-  args: {
+  args: UsageDisplay & {
     toolUses: number;
     turnCount?: number;
     maxTurns?: number;
-    input: number;
-    output: number;
-    contextPercent: number | null;
-    compactions: number;
-    cost?: number;
     durationMs?: number;
   },
   theme: Theme,
   visible?: StatsVisibility,
 ): string[] {
   const parts: string[] = [];
-  if (visible?.showTools !== false && args.toolUses > 0) parts.push(`${args.toolUses}🛠 `);
+  if (visible?.showTools !== false && args.toolUses > 0) parts.push(`${args.toolUses}🛠`);
   if (visible?.showTurns !== false && args.turnCount != null) parts.push(formatTurns(args.turnCount, args.maxTurns, theme));
-  if (visible?.showInput !== false || visible?.showOutput !== false) {
-    const showIn = visible?.showInput !== false;
-    const showOut = visible?.showOutput !== false;
-    const inputTokens = showIn ? args.input : 0;
-    const outputTokens = showOut ? args.output : 0;
-    if (inputTokens > 0 || outputTokens > 0) {
-      parts.push(formatSessionTokens(
-        inputTokens, outputTokens,
-        visible?.showContext !== false ? args.contextPercent : null,
-        theme,
-        visible?.showContext !== false ? args.compactions : 0,
-      ));
-    }
-  }
-  if (visible?.showCost !== false && args.cost != null && args.cost > 0) parts.push(formatCost(args.cost));
+  const usage = formatUsageBlock(args, visible, theme);
+  if (usage) parts.push(usage);
   if (visible?.showTime !== false && args.durationMs != null) parts.push(formatMs(args.durationMs));
   return parts;
 }
@@ -269,12 +260,21 @@ export function formatDuration(startedAt: number, completedAt?: number): string 
   return `${formatMs(Date.now() - startedAt)} (running)`;
 }
 
+/** Format a concrete thinking level for display; omitted or inherited values have no tag. */
+export function formatThinkingTag(value: unknown): string | undefined {
+  const thinkingLevel = typeof value === "string" ? parseThinkingLevel(value) : undefined;
+  return thinkingLevel ? `thinking: ${thinkingLevel}` : undefined;
+}
+
 /** Build invocation display tags from an AgentInvocation. */
-export function buildInvocationTags(invocation: AgentInvocation | undefined): { modelName?: string; tags: string[] } {
+export function buildInvocationTags(invocation: AgentInvocation | undefined): { modelName?: string; thinkingTag?: string; tags: string[] } {
   const tags: string[] = [];
   if (!invocation) return { tags };
-  if (invocation.thinkingLevel) tags.push(`thinking: ${invocation.thinkingLevel}`);
   if (invocation.runInBackground) tags.push("background");
   if (invocation.maxTurns != null) tags.push(`max turns: ${invocation.maxTurns}`);
-  return { modelName: invocation.modelName, tags };
+  return {
+    modelName: invocation.modelName,
+    thinkingTag: formatThinkingTag(invocation.thinkingLevel),
+    tags,
+  };
 }

--- a/src/ui/menu/menu-running-agents.ts
+++ b/src/ui/menu/menu-running-agents.ts
@@ -19,7 +19,7 @@ import { Input, matchesKey, SelectList, truncateToWidth, visibleWidth, type Comp
 import type { AgentRecord } from "../../types.js";
 import { SHORT_ID_LENGTH } from "../../types.js";
 import { ConversationViewer } from "../conversation-viewer.js";
-import { getDisplayName, truncateDesc } from "../format.js";
+import { getAgentStatusDisplay, getDisplayName, truncateDesc } from "../format.js";
 import { buildSelectListTheme, createDelegatingComponent } from "./helpers.js";
 import { getCoordinator, getManager, getStore } from "../../shell.js";
 import type { Theme } from "../types.js";
@@ -46,6 +46,7 @@ async function showConversationViewer(
         () => manager?.abort(record.id, "user"),
         kb,
         (msg: string) => manager?.steer(record.id, msg),
+        getStore().agent,
       ),
     { overlay: true },
   );
@@ -254,10 +255,7 @@ export async function showRunningAgentsMenu(
     const buildAgentItems = (): SelectItem[] => {
       const items: SelectItem[] = agents.map((record) => {
         const elapsed = Math.round((Date.now() - record.lifecycle.startedAt) / 1000);
-        const statusIcon = record.lifecycle.status === "running" ? "\u25B6" :
-          record.lifecycle.status === "completed" ? "\u2713" :
-          record.lifecycle.status === "queued" ? "\u23F3" :
-          record.lifecycle.status === "error" ? "\u2717" : "\u2022";
+        const { icon: statusIcon } = getAgentStatusDisplay(record.lifecycle.status);
         const descLen = getStore().agent.widgetDescLengthFull;
         const headline = record.display.description
           ? truncateDesc(record.display.description, descLen)
@@ -265,7 +263,7 @@ export async function showRunningAgentsMenu(
         const suffix = headline ? ` \u2014 ${headline}` : "";
         return {
           value: record.id,
-          label: `${statusIcon} ${record.id.slice(0, SHORT_ID_LENGTH)}  ${record.display.type}  ${record.lifecycle.status}  ${elapsed}s${suffix}`,
+          label: `${statusIcon} ${record.id.slice(0, SHORT_ID_LENGTH)}  ${getDisplayName(record.display.type)}  ${record.lifecycle.status}  ${elapsed}s${suffix}`,
         };
       });
       if (running.length > 0) {

--- a/src/ui/menu/menu-widget-settings.ts
+++ b/src/ui/menu/menu-widget-settings.ts
@@ -6,7 +6,7 @@
  * reset bug that occurred with ctx.ui.select.
  *
  * Structure:
- *   Main list: compact, maxLines, descLengthFull, maxLinesCompact, descLengthCompact, shortcut, usageStats
+ *   Main list: compact, maxLines, descriptions, shortcut, model/thinking, start time, navigation hint, retention, usageStats
  *   Usage stats submenu: 7 stat visibility toggles
  *
  * Exports:
@@ -59,6 +59,14 @@ export async function showWidgetSettingsMenu(ctx: ExtensionCommandContext): Prom
         store.mutate.agent.setOutputThinkingBufferSize(newValue === "OFF" ? 0 : Number(newValue));
         ctx.ui.notify(`Thinking buffer ${newValue}`, "info");
         break;
+      case "showModelThinking":
+        store.mutate.widget.setShowModelThinking(newValue === "ON");
+        ctx.ui.notify(`Show model & thinking ${newValue}`, "info");
+        break;
+      case "showStartTime":
+        store.mutate.widget.setShowStartTime(newValue === "ON");
+        ctx.ui.notify(`Show local start time ${newValue}`, "info");
+        break;
       case "navHint":
         store.mutate.widget.setNavHint(newValue === "ON");
         ctx.ui.notify(`Navigation hint ${newValue}`, "info");
@@ -101,7 +109,7 @@ export async function showWidgetSettingsMenu(ctx: ExtensionCommandContext): Prom
           store.mutate.widget.setMaxLines(parsed);
           ctx.ui.notify(`Max lines (full) set to ${parsed}`, "info");
         }),
-        description: "Max body lines in full widget mode (excluding heading).",
+        description: "Max total lines in full widget mode, including the heading.",
       },
       {
         id: "descLengthFull",
@@ -117,11 +125,11 @@ export async function showWidgetSettingsMenu(ctx: ExtensionCommandContext): Prom
         id: "maxLinesCompact",
         label: "Max lines (compact)",
         currentValue: String(store.agent.widgetMaxLinesCompact),
-        submenu: createNumericSubmenu(ctx, (parsed) => {
+        submenu: createNumericSubmenu(ctx, { min: 2 }, (parsed) => {
           store.mutate.widget.setMaxLinesCompact(parsed);
           ctx.ui.notify(`Max lines (compact) set to ${parsed}`, "info");
         }),
-        description: "Max body lines in compact widget mode.",
+        description: "Max total lines in compact widget mode, including the heading.",
       },
       {
         id: "descLengthCompact",
@@ -139,6 +147,20 @@ export async function showWidgetSettingsMenu(ctx: ExtensionCommandContext): Prom
         currentValue: store.agent.widgetShortcut ? "ON" : "OFF",
         values: ["ON", "OFF"],
         description: "When ON, ctrl+o toggles compact mode; when OFF, compact is set manually.",
+      },
+      {
+        id: "showModelThinking",
+        label: "Show model & thinking",
+        currentValue: store.agent.widgetShowModelThinking ? "ON" : "OFF",
+        values: ["ON", "OFF"],
+        description: "Show each agent's model name and thinking level in one column.",
+      },
+      {
+        id: "showStartTime",
+        label: "Show local start time",
+        currentValue: store.agent.widgetShowStartTime ? "ON" : "OFF",
+        values: ["ON", "OFF"],
+        description: "Show local HH:MM start time after each agent status symbol.",
       },
       {
         id: "navHint",
@@ -175,7 +197,7 @@ export async function showWidgetSettingsMenu(ctx: ExtensionCommandContext): Prom
       },
     ];
 
-    const settingsList = new SettingsList(items, 15, buildSettingsListTheme(theme), onChange, () => done(undefined));
+    const settingsList = new SettingsList(items, 16, buildSettingsListTheme(theme), onChange, () => done(undefined));
     return new SettingsListWrapper(settingsList, { title: "Widget Settings", theme, onCancel: () => done(undefined) });
   });
 }

--- a/src/ui/menu/menu-widget-settings.ts
+++ b/src/ui/menu/menu-widget-settings.ts
@@ -68,7 +68,7 @@ export async function showWidgetSettingsMenu(ctx: ExtensionCommandContext): Prom
 
   await ctx.ui.custom((_tui, theme, _kb, done) => {
     const statDescriptions: Record<string, string> = {
-      showTools: "Show tool count (🛠 ) in the widget.",
+      showTools: "Show tool count (⚙︎) in the widget.",
       showTurns: "Show turn count (⟳ ) in the widget.",
       showInput: "Show input tokens (↑) in the widget.",
       deltaInputTokens: "Estimate input token delta for vLLM (no cache reporting).",

--- a/src/ui/renderer.ts
+++ b/src/ui/renderer.ts
@@ -6,17 +6,19 @@
 
 import { Box, Container, Spacer, Text } from "@earendil-works/pi-tui";
 import type { Theme } from "./types.js";
-import { buildStatsParts, formatMs, getDisplayName } from "./format.js";
+import { buildStatsParts, formatMs, formatThinkingTag, getDisplayName } from "./format.js";
 
 // ============================================================================
 // Stats rendering helpers
 // ============================================================================
 
-/** Format agent display name with optional model: "Agent (mimo-v2.5-pro)" or "Agent". */
+/** Format agent display name with optional model and thinking level. */
 export function agentNameLabel(d: Record<string, unknown>, theme: Theme): string {
   const typeName = getDisplayName((d.type as string) || "");
-  const modelName = d.modelName as string | undefined;
-  return modelName ? `${theme.bold(typeName)} (${modelName})` : theme.bold(typeName);
+  const modelName = typeof d.modelName === "string" && d.modelName.trim() ? d.modelName.trim() : undefined;
+  const thinkingTag = formatThinkingTag(d.thinkingLevel);
+  const label = [modelName, thinkingTag].filter((part): part is string => part !== undefined).join(" · ");
+  return label ? `${theme.bold(typeName)} (${label})` : theme.bold(typeName);
 }
 
 /** Build the stats line for an agent result card. */
@@ -27,12 +29,17 @@ export function buildStatsLine(d: Record<string, unknown>, theme: Theme, showCos
     maxTurns: d.maxTurns as number | undefined,
     input: (d.input as number) ?? 0,
     output: (d.output as number) ?? 0,
+    cacheRead: d.cacheRead as number | undefined,
+    cacheWrite: d.cacheWrite as number | undefined,
+    latestCacheHitRate: d.latestCacheHitRate as number | undefined,
     contextPercent: d.contextPercent as number | null,
-    compactions: (d.compactions as number) ?? 0,
+    contextWindow: d.contextWindow as number | undefined,
+    autoCompactionEnabled: d.autoCompactionEnabled as boolean | undefined,
     cost: showCost ? (d.cost as number | undefined) : undefined,
+    usingSubscription: showCost ? (d.usingSubscription as boolean | undefined) : undefined,
   }, theme);
   parts.push(formatMs(d.durationMs as number));
-  return parts.join("·");
+  return parts.join(" · ");
 }
 
 // ============================================================================
@@ -48,10 +55,12 @@ export function renderAgentToolCall(
   const label = typeName || "Agent";
   let text = `▸ ${theme.fg("accent", theme.bold(label))}`;
 
-  const modelOverride = args._modelOverride as string | undefined;
-  if (modelOverride) {
-    text += ` (${modelOverride})`;
-  }
+  const modelOverride = typeof args._modelOverride === "string" && args._modelOverride.trim()
+    ? args._modelOverride.trim()
+    : undefined;
+  const thinkingTag = formatThinkingTag(args.thinking);
+  const details = [modelOverride, thinkingTag].filter((part): part is string => part !== undefined).join(" · ");
+  if (details) text += ` (${details})`;
 
   return new Text(text, 0, 0);
 }
@@ -72,7 +81,7 @@ export function renderAgentToolResult(
   if (d && d.turnCount != null) {
     const namePart = agentNameLabel(d, theme);
     const statsLine = buildStatsLine(d, theme, showCost);
-    let lines = `${icon} ${namePart}·${statsLine}\n  ${theme.fg("text", desc)}`;
+    let lines = `${icon} ${namePart} · ${statsLine}\n  ${theme.fg("text", desc)}`;
     if (expanded && text) {
       lines += "\n" + text.split("\n").map(l => `  ${l}`).join("\n");
     }
@@ -114,7 +123,7 @@ export function renderSubagentResult(
 
     const namePart = agentNameLabel(d, theme);
     const statsLine = buildStatsLine(d, theme, showCost);
-    let headerLine = `${icon} ${namePart}·${statsLine}\n  ${theme.fg("text", (d.description as string) || "")}`;
+    let headerLine = `${icon} ${namePart} · ${statsLine}\n  ${theme.fg("text", (d.description as string) || "")}`;
     if (d.outputFile as string) {
       headerLine += `\n  ${theme.fg("dim", `tail -f ${d.outputFile}`)}`;
     }

--- a/src/ui/renderer.ts
+++ b/src/ui/renderer.ts
@@ -6,7 +6,7 @@
 
 import { Box, Container, Spacer, Text } from "@earendil-works/pi-tui";
 import type { Theme } from "./types.js";
-import { buildStatsParts, formatMs, formatThinkingTag, getDisplayName } from "./format.js";
+import { buildStatsCells, formatStatsRow, formatThinkingTag, getDisplayName } from "./format.js";
 
 // ============================================================================
 // Stats rendering helpers
@@ -23,7 +23,7 @@ export function agentNameLabel(d: Record<string, unknown>, theme: Theme): string
 
 /** Build the stats line for an agent result card. */
 export function buildStatsLine(d: Record<string, unknown>, theme: Theme, showCost: boolean): string {
-  const parts = buildStatsParts({
+  const cells = buildStatsCells({
     toolUses: (d.toolUses as number) ?? 0,
     turnCount: d.turnCount as number | undefined,
     maxTurns: d.maxTurns as number | undefined,
@@ -37,9 +37,9 @@ export function buildStatsLine(d: Record<string, unknown>, theme: Theme, showCos
     autoCompactionEnabled: d.autoCompactionEnabled as boolean | undefined,
     cost: showCost ? (d.cost as number | undefined) : undefined,
     usingSubscription: showCost ? (d.usingSubscription as boolean | undefined) : undefined,
+    durationMs: d.durationMs as number,
   }, theme);
-  parts.push(formatMs(d.durationMs as number));
-  return parts.join(" · ");
+  return formatStatsRow(cells) ?? "";
 }
 
 // ============================================================================

--- a/src/ui/renderer.ts
+++ b/src/ui/renderer.ts
@@ -6,7 +6,8 @@
 
 import { Box, Container, Spacer, Text } from "@earendil-works/pi-tui";
 import type { Theme } from "./types.js";
-import { buildStatsCells, formatStatsRow, formatThinkingTag, getDisplayName } from "./format.js";
+import { buildStatsCells, formatStatsRow, formatThinkingTag, getAgentStatusDisplay, getDisplayName } from "./format.js";
+import type { AgentStatus } from "../types.js";
 
 // ============================================================================
 // Stats rendering helpers
@@ -118,12 +119,13 @@ export function renderSubagentResult(
   inner.addChild(new Spacer(1));
 
   if (d && d.turnCount != null) {
-    const isError = d.status === "error" || d.status === "aborted" || d.status === "stopped";
-    const icon = isError ? theme.fg("error", "✗") : theme.fg("success", "✓");
+    const status = (d.status as AgentStatus | undefined) ?? "completed";
+    const { icon, color } = getAgentStatusDisplay(status);
+    const statusIcon = theme.fg(color, icon);
 
     const namePart = agentNameLabel(d, theme);
     const statsLine = buildStatsLine(d, theme, showCost);
-    let headerLine = `${icon} ${namePart} · ${statsLine}\n  ${theme.fg("text", (d.description as string) || "")}`;
+    let headerLine = `${statusIcon} ${namePart} · ${statsLine}\n  ${theme.fg("text", (d.description as string) || "")}`;
     if (d.outputFile as string) {
       headerLine += `\n  ${theme.fg("dim", `tail -f ${d.outputFile}`)}`;
     }
@@ -156,8 +158,9 @@ function buildFallbackResultLine(
   text: string,
   theme: Theme,
 ): string {
-  const icon = theme.fg("success", "✓");
-  let line = icon;
+  const status = (d?.status as AgentStatus | undefined) ?? "completed";
+  const { icon, color } = getAgentStatusDisplay(status);
+  let line = theme.fg(color, icon);
   if (d?.type) {
     line += ` ${agentNameLabel(d, theme)}`;
   }

--- a/test/agents/agent-manager.test.ts
+++ b/test/agents/agent-manager.test.ts
@@ -515,6 +515,12 @@ describe("delta estimation", () => {
     return callbacks.onAssistantUsage;
   }
 
+  function getOnSupplementalUsage() {
+    const call = mockModules.mockRunAgent.mock.calls[mockModules.mockRunAgent.mock.calls.length - 1];
+    const callbacks = call[3]; // 4th arg is the callbacks object
+    return callbacks.onSupplementalUsage;
+  }
+
   beforeEach(() => {
     mockStoreState.deltaInputTokens = true;
   });
@@ -621,6 +627,30 @@ describe("delta estimation", () => {
     expect(stats.cacheRead).toBe(230);
     expect(stats.latestCacheHitRate).toBeCloseTo((150 / 400) * 100);
     expect(stats.lifetimeUsage.cacheWrite).toBe(70);
+  });
+
+  it("counts supplemental usage without changing assistant delta or cache-hit state", () => {
+    manager = new AgentManager(onComplete);
+    mockModules.mockRunAgent.mockResolvedValue(mockRunResult());
+    const id = manager.spawn(fakePi(), fakeCtx(), "general-purpose", "task", { description: "task", modelKey: "test/model" });
+    const onAssistantUsage = getOnAssistantUsage();
+    const onSupplementalUsage = getOnSupplementalUsage();
+
+    onAssistantUsage({ input: 100, output: 10, cacheRead: 80, cacheWrite: 20, cost: 0.01 });
+    const stats = manager.getRecord(id)!.stats;
+    const assistantCacheHitRate = stats.latestCacheHitRate;
+
+    onSupplementalUsage({ input: 400, output: 50, cacheRead: 300, cacheWrite: 25, cost: 0.12 });
+
+    expect(stats.lifetimeUsage).toEqual({ input: 500, output: 60, cacheWrite: 45, cost: 0.13 });
+    expect(stats.cacheRead).toBe(380);
+    expect(stats.prevInputTokens).toBe(100);
+    expect(stats.latestCacheHitRate).toBe(assistantCacheHitRate);
+
+    // The next assistant report still uses the previous assistant input (100),
+    // rather than the compaction input (400), for the vLLM delta heuristic.
+    onAssistantUsage({ input: 200, output: 10, cacheRead: 0, cacheWrite: 0, cost: 0 });
+    expect(stats.lifetimeUsage.input).toBe(600);
   });
 
   it("persists final context, auto-compaction, and subscription snapshots", async () => {

--- a/test/agents/agent-manager.test.ts
+++ b/test/agents/agent-manager.test.ts
@@ -416,6 +416,61 @@ describe("AgentManager", () => {
       expect(manager.getTotalAgentCost()).toBe(0.04);
     });
   });
+
+  // ── Cumulative agent count ──
+
+  describe("totalAgentCount", () => {
+    it("counts accepted running and queued spawns exactly once", async () => {
+      const config: ConcurrencyConfig = { default: 1, models: { "test/model": 1 } };
+      manager = new AgentManager(onComplete, config);
+      const first = makeResolvablePromise();
+      const second = makeResolvablePromise();
+      mockModules.mockRunAgent
+        .mockReturnValueOnce(first.promise)
+        .mockReturnValueOnce(second.promise);
+
+      const id1 = manager.spawn(fakePi(), fakeCtx(), "general-purpose", "first", { description: "first", modelKey: "test/model" });
+      const id2 = manager.spawn(fakePi(), fakeCtx(), "general-purpose", "second", { description: "second", modelKey: "test/model" });
+
+      expect(manager.getRecord(id2)?.lifecycle.status).toBe("queued");
+      expect(manager.getTotalAgentCount()).toBe(2);
+
+      first.resolve(mockRunResult());
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(manager.getRecord(id2)?.lifecycle.status).toBe("running");
+      expect(manager.getTotalAgentCount()).toBe(2);
+
+      second.resolve(mockRunResult());
+      await manager.getRecord(id2)!.execution.promise;
+      await manager.getRecord(id1)!.execution.promise;
+    });
+
+    it("does not count a synchronously failed start", () => {
+      manager = new AgentManager(onComplete);
+      mockModules.mockRunAgent.mockImplementationOnce(() => {
+        throw new Error("start failed");
+      });
+
+      expect(() => manager.spawn(fakePi(), fakeCtx(), "general-purpose", "task", { description: "task", modelKey: "test/model" })).toThrow("start failed");
+      expect(manager.getTotalAgentCount()).toBe(0);
+    });
+
+    it("persists after an agent is evicted", async () => {
+      manager = new AgentManager(onComplete);
+      mockModules.mockRunAgent.mockResolvedValue(mockRunResult());
+
+      const id = manager.spawn(fakePi(), fakeCtx(), "general-purpose", "task", { description: "task", modelKey: "test/model" });
+      const record = manager.getRecord(id)!;
+      await record.execution.promise;
+      record.lifecycle.resultConsumed = true;
+      record.lifecycle.completedAt = Date.now() - 20 * 60_000;
+      (manager as any).cleanup();
+
+      expect(manager.getRecord(id)).toBeUndefined();
+      expect(manager.getTotalAgentCount()).toBe(1);
+    });
+  });
+
   // ── Cleanup eviction ──
 
   describe("cleanup", () => {

--- a/test/agents/agent-manager.test.ts
+++ b/test/agents/agent-manager.test.ts
@@ -607,5 +607,40 @@ describe("delta estimation", () => {
     onUsage({ input: 250, output: 30, cacheWrite: 0, cost: 0, cacheRead: 0 });
     expect(record.stats.lifetimeUsage.input).toBe(350); // 100 + 250 (full, no delta)
   });
+
+  it("accumulates cache reads and retains only the newest cache-hit rate", () => {
+    manager = new AgentManager(onComplete);
+    mockModules.mockRunAgent.mockResolvedValue(mockRunResult());
+    const id = manager.spawn(fakePi(), fakeCtx(), "general-purpose", "task", { description: "task", modelKey: "test/model" });
+    const onUsage = getOnAssistantUsage();
+
+    onUsage({ input: 100, output: 10, cacheRead: 80, cacheWrite: 20, cost: 0 });
+    onUsage({ input: 200, output: 10, cacheRead: 150, cacheWrite: 50, cost: 0 });
+
+    const stats = manager.getRecord(id)!.stats;
+    expect(stats.cacheRead).toBe(230);
+    expect(stats.latestCacheHitRate).toBeCloseTo((150 / 400) * 100);
+    expect(stats.lifetimeUsage.cacheWrite).toBe(70);
+  });
+
+  it("persists final context, auto-compaction, and subscription snapshots", async () => {
+    manager = new AgentManager(onComplete);
+    const session = {
+      ...mockAgentSession(),
+      getContextUsage: () => ({ percent: 23.4, contextWindow: 272_000 }),
+      autoCompactionEnabled: true,
+      model: { provider: "kimi-coding" },
+    };
+    mockModules.mockRunAgent.mockResolvedValue(mockRunResult({ session }));
+    const id = manager.spawn(fakePi(), fakeCtx(), "general-purpose", "task", { description: "task", modelKey: "test/model" });
+    await manager.getRecord(id)!.execution.promise;
+
+    expect(manager.getRecord(id)!.stats).toMatchObject({
+      contextPercent: 23.4,
+      contextWindow: 272_000,
+      autoCompactionEnabled: true,
+      usingSubscription: true,
+    });
+  });
 });
 }); // end describe AgentManager

--- a/test/agents/agent-runner.test.ts
+++ b/test/agents/agent-runner.test.ts
@@ -36,7 +36,7 @@ const mockModules = vi.hoisted(() => ({
   mockLoadSkillMeta: vi.fn().mockReturnValue([]),
   mockCreateAgentSession: vi.fn(),
   mockDefaultResourceLoader: MockDefaultResourceLoader,
-  mockGetAgentDir: vi.fn(),
+  mockGetAgentDir: vi.fn(() => "/home/test/.pi/agent"),
   mockLoadProjectContextFiles: vi.fn().mockReturnValue([]),
   mockIncludeContextFiles: true as boolean,
   mockSystemPromptMode: "replace" as string,

--- a/test/agents/agent-runner.test.ts
+++ b/test/agents/agent-runner.test.ts
@@ -536,6 +536,62 @@ describe("subscribeToSessionEvents — cost extraction", () => {
     unsub();
   });
 
+  it("reports successful compaction usage separately from assistant usage", () => {
+    const onAssistantUsage = vi.fn();
+    const onSupplementalUsage = vi.fn();
+    const onCompaction = vi.fn();
+    const session = createMockSession();
+    const unsub = subscribeToSessionEvents(session, { onAssistantUsage, onSupplementalUsage, onCompaction });
+
+    session._getListeners()[0]({
+      type: "compaction_end",
+      reason: "threshold",
+      aborted: false,
+      result: {
+        tokensBefore: 1000,
+        usage: { input: 400, output: 50, cacheRead: 300, cacheWrite: 25, cost: { total: 0.12 } },
+      },
+    });
+
+    expect(onSupplementalUsage).toHaveBeenCalledWith({
+      input: 400,
+      output: 50,
+      cacheRead: 300,
+      cacheWrite: 25,
+      cost: 0.12,
+    });
+    expect(onAssistantUsage).not.toHaveBeenCalled();
+    expect(onCompaction).toHaveBeenCalledWith({ reason: "threshold", tokensBefore: 1000 });
+
+    unsub();
+  });
+
+  it("reports typed tool-result usage separately from assistant usage", () => {
+    const onAssistantUsage = vi.fn();
+    const onSupplementalUsage = vi.fn();
+    const session = createMockSession();
+    const unsub = subscribeToSessionEvents(session, { onAssistantUsage, onSupplementalUsage });
+
+    session._getListeners()[0]({
+      type: "message_end",
+      message: {
+        role: "toolResult",
+        usage: { input: 30, output: 5, cacheRead: 20, cacheWrite: 10, cost: { total: 0.03 } },
+      },
+    });
+
+    expect(onSupplementalUsage).toHaveBeenCalledWith({
+      input: 30,
+      output: 5,
+      cacheRead: 20,
+      cacheWrite: 10,
+      cost: 0.03,
+    });
+    expect(onAssistantUsage).not.toHaveBeenCalled();
+
+    unsub();
+  });
+
   it("does not fire onAssistantUsage for user message_end events", () => {
     const onAssistantUsage = vi.fn();
     const session = createMockSession();

--- a/test/agents/build-agent-details.test.ts
+++ b/test/agents/build-agent-details.test.ts
@@ -45,6 +45,11 @@ describe("buildAgentDetails", () => {
         turnCount: 10,
         maxTurns: 25,
         compactionCount: 1,
+        cacheRead: 75,
+        latestCacheHitRate: 50,
+        contextWindow: 128000,
+        autoCompactionEnabled: true,
+        usingSubscription: true,
       },
     };
     // Deep merge overrides into the base record
@@ -93,7 +98,13 @@ describe("buildAgentDetails", () => {
     expect(details.input).toBeDefined();
     expect(details.output).toBeDefined();
     expect(details.cost).toBe(0.01);
-    expect(details.contextPercent).toBeDefined();
+    expect(details.contextPercent).toBeNull();
+    expect(details.contextWindow).toBe(128000);
+    expect(details.autoCompactionEnabled).toBe(true);
+    expect(details.usingSubscription).toBe(true);
+    expect(details.cacheRead).toBe(75);
+    expect(details.cacheWrite).toBe(50);
+    expect(details.latestCacheHitRate).toBe(50);
     expect(details.durationMs).toBeDefined();
     expect(details.compactions).toBe(1);
     expect(details.modelName).toBeUndefined(); // no invocation set
@@ -123,11 +134,12 @@ describe("buildAgentDetails", () => {
     expect(details.durationMs).toBe(0);
   });
 
-  it("includes modelName from invocation", () => {
-    const record = makeRecord({ display: { type: "builder", description: "Build something", invocation: { modelName: "haiku" } } });
+  it("includes modelName and thinkingLevel from invocation", () => {
+    const record = makeRecord({ display: { type: "builder", description: "Build something", invocation: { modelName: "haiku", thinkingLevel: "high" } } });
     const details = buildAgentDetails(record, { includeStats: true });
 
     expect(details.modelName).toBe("haiku");
+    expect(details.thinkingLevel).toBe("high");
   });
 
   // --- includeStatus ---

--- a/test/agents/output-file.test.ts
+++ b/test/agents/output-file.test.ts
@@ -129,7 +129,7 @@ describe("streamToOutputFile", () => {
     expect(lastLine).toMatch(/\[DONE\]/);
     expect(lastLine).toContain("3 turns");
     expect(lastLine).toContain("5 tool uses");
-    expect(lastLine).toContain("12.4k tokens");
+    expect(lastLine).toContain("12k tokens");
     expect(lastLine).toContain("$0.024");
   });
 

--- a/test/agents/output-file.test.ts
+++ b/test/agents/output-file.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
 import { createMockSession, tempDirFixture } from "../fixtures.ts";
 import {
   createOutputFilePath,
@@ -29,10 +30,10 @@ describe("createOutputFilePath", () => {
   it("returns <baseDir>/<agentId>.log", () => {
     const dir = fixture.getDir();
     const result = createOutputFilePath(testAgentId, dir);
-    expect(result).toBe(`${dir}/${testAgentId}.log`);
+    expect(result).toBe(join(dir, `${testAgentId}.log`));
   });
 
-  it("creates the directory with 0o700 permissions", () => {
+  it.skipIf(process.platform === "win32")("creates the directory with 0o700 permissions", () => {
     const dir = fixture.getDir() + "/sub";
     createOutputFilePath(testAgentId, dir);
     expect(existsSync(dir)).toBe(true);
@@ -46,7 +47,7 @@ describe("createOutputFilePath", () => {
   });
 
   it("defaults to /tmp/pi-agent-outputs when baseDir is omitted", () => {
-    expect(createOutputFilePath("test")).toBe("/tmp/pi-agent-outputs/test.log");
+    expect(createOutputFilePath("test")).toBe(join("/tmp/pi-agent-outputs", "test.log"));
   });
 });
 
@@ -434,13 +435,13 @@ describe("AgentOutputLog", () => {
   it("creates the output file path and writes initial [USER] entry", () => {
     const dir = fixture.getDir();
     const log = new AgentOutputLog(testAgentId, "explore auth", dir);
-    expect(log.path).toBe(`${dir}/${testAgentId}.log`);
+    expect(log.path).toBe(join(dir, `${testAgentId}.log`));
     expect(readFileSync(log.path, "utf-8")).toMatch(/\[USER\]\s+explore auth/);
   });
 
   it("uses default baseDir when omitted", () => {
     const log = new AgentOutputLog(testAgentId, "test prompt");
-    expect(log.path).toBe(`/tmp/pi-agent-outputs/${testAgentId}.log`);
+    expect(log.path).toBe(join("/tmp/pi-agent-outputs", `${testAgentId}.log`));
   });
 
   it("subscribes to session events on attach", () => {
@@ -522,6 +523,6 @@ describe("AgentOutputLog", () => {
   it("exposes the output file path as a readonly property", () => {
     const dir = fixture.getDir();
     const log = new AgentOutputLog(testAgentId, "test", dir);
-    expect(log.path).toBe(`${dir}/${testAgentId}.log`);
+    expect(log.path).toBe(join(dir, `${testAgentId}.log`));
   });
 });

--- a/test/agents/tool-execution.test.ts
+++ b/test/agents/tool-execution.test.ts
@@ -21,11 +21,33 @@ import { fakeCtx } from "../fixtures.ts";
 /* ------------------------------------------------------------------ */
 
 // Use vi.hoisted so mock factories can reference these at hoisting time
-const { mockValidateWorktreePath, mockSpawn, mockGetRecord, mockDiscoverNewAgents } = vi.hoisted(() => ({
+const { mockValidateWorktreePath, mockSpawn, mockGetRecord, mockDiscoverNewAgents, mockCoordinatorSpawn } = vi.hoisted(() => ({
   mockValidateWorktreePath: vi.fn(),
   mockSpawn: vi.fn().mockReturnValue("agent-id-123"),
   mockGetRecord: vi.fn(),
   mockDiscoverNewAgents: vi.fn(),
+  mockCoordinatorSpawn: vi.fn(async (_pi: any, _ctx: any, intent: any) => {
+    const manager = {
+      spawn: mockSpawn,
+      getRecord: mockGetRecord,
+    };
+    const id = manager.spawn(_pi, _ctx, intent.type, intent.prompt, {
+      description: intent.description,
+      model: intent.model,
+      maxTurns: intent.maxTurns,
+      thinkingLevel: intent.thinkingLevel,
+      modelKey: intent.modelKey,
+      graceTurns: intent.graceTurns,
+      worktreePath: intent.worktreePath,
+      worktreeLabel: intent.worktreeLabel,
+      isBackground: intent.runInBackground,
+    });
+    const record = manager.getRecord(id);
+    if (!intent.runInBackground && record?.execution?.promise) {
+      await record.execution.promise;
+    }
+    return { agentId: id, record };
+  }),
 }));
 
 vi.mock("../../src/spawn/worktree-validator.js", () => ({
@@ -78,29 +100,7 @@ vi.mock("../../src/shell.js", () => ({
     update: vi.fn(),
   }),
   getCoordinator: () => ({
-    spawn: vi.fn(async (_pi: any, _ctx: any, intent: any) => {
-      // Delegate to the mocked manager.spawn
-      const manager = {
-        spawn: mockSpawn,
-        getRecord: mockGetRecord,
-      };
-      const id = mockSpawn(_pi, _ctx, intent.type, intent.prompt, {
-        description: intent.description,
-        model: intent.model,
-        maxTurns: intent.maxTurns,
-        thinkingLevel: intent.thinkingLevel,
-        modelKey: intent.modelKey,
-        graceTurns: intent.graceTurns,
-        worktreePath: intent.worktreePath,
-        worktreeLabel: intent.worktreeLabel,
-        isBackground: intent.runInBackground,
-      });
-      const record = mockGetRecord(id);
-      if (!intent.runInBackground && record?.execution?.promise) {
-        await record.execution.promise;
-      }
-      return { agentId: id, record };
-    }),
+    spawn: mockCoordinatorSpawn,
     isBackground: vi.fn(() => false),
     scheduleNudge: vi.fn(),
     onAgentComplete: vi.fn(),
@@ -111,12 +111,13 @@ vi.mock("../../src/shell.js", () => ({
 vi.mock("../../src/agents/usage.js", () => ({
   addUsage: vi.fn(),
   getLifetimeTotal: vi.fn(() => 0),
-  getSessionContextPercent: vi.fn(() => null),
+  getSessionUsageSnapshot: vi.fn(() => undefined),
 }));
 
 // Import after mocks are in place
 import { executeAgentTool } from "../../src/agents/tool-execution.js";
 import * as agentTypes from "../../src/agents/agent-types.js";
+import * as utils from "../../src/utils.js";
 
 /* ------------------------------------------------------------------ */
 /*  Factories                                                         */
@@ -301,6 +302,22 @@ describe("executeAgentTool — worktree_path validation", () => {
 
     expect(result.isError).toBeUndefined();
     expect(result.content[0].text).toBe("Agent completed successfully");
+  });
+
+  it("stores the resolved thinking level in the tool spawn invocation", async () => {
+    vi.mocked(agentTypes.getAgentConfig).mockReturnValue({ maxTurns: 25, thinkingLevel: "high" } as any);
+    vi.mocked(utils.findModelInRegistry).mockReturnValue({ provider: "anthropic", id: "sonnet" } as any);
+
+    await executeAgentTool("tc-thinking", makeParams({ model: "anthropic/sonnet" }), undefined, undefined, ctx);
+
+    expect(mockCoordinatorSpawn).toHaveBeenCalledWith(
+      expect.anything(),
+      ctx,
+      expect.objectContaining({
+        thinkingLevel: "high",
+        invocation: { modelName: "sonnet", thinkingLevel: "high" },
+      }),
+    );
   });
 
   it("does not crash the parent when validator throws unexpectedly", async () => {

--- a/test/agents/tool-execution.test.ts
+++ b/test/agents/tool-execution.test.ts
@@ -93,6 +93,7 @@ vi.mock("../../src/shell.js", () => ({
     getRecord: mockGetRecord,
     listAgents: vi.fn(() => []),
     getTotalAgentCost: vi.fn(() => 0),
+    getTotalAgentCount: vi.fn(() => 0),
     abort: vi.fn(() => false),
   }),
   getWidget: () => ({

--- a/test/agents/usage.test.ts
+++ b/test/agents/usage.test.ts
@@ -1,147 +1,60 @@
-/**
- * usage.test.ts — Tests for usage tracking utilities.
- *
- * Tests cover:
- *   - LifetimeUsage type includes cost field
- *   - addUsage accumulates cost alongside tokens
- *   - getLifetimeTotal includes cost in sum
- *   - Backward compatibility (existing token fields unchanged)
- */
-
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
-  type LifetimeUsage,
   addUsage,
-  getLifetimeTotal,
-  formatTokens,
   formatCost,
+  formatTokens,
+  getLifetimeTotal,
+  getSessionUsageSnapshot,
+  type LifetimeUsage,
 } from "../../src/agents/usage.js";
 
-/* ------------------------------------------------------------------ */
-/*  LifetimeUsage type — cost field                                    */
-/* ------------------------------------------------------------------ */
-
-describe("LifetimeUsage", () => {
-  it("includes cost field", () => {
-    const u: LifetimeUsage = { input: 100, output: 50, cacheWrite: 10, cost: 5 };
-    expect(u.cost).toBe(5);
-  });
-
-  it("has correct shape with all fields", () => {
-    const u: LifetimeUsage = { input: 0, output: 0, cacheWrite: 0, cost: 0 };
-    expect(u).toHaveProperty("input");
-    expect(u).toHaveProperty("output");
-    expect(u).toHaveProperty("cacheWrite");
-    expect(u).toHaveProperty("cost");
-  });
-});
-
-/* ------------------------------------------------------------------ */
-/*  addUsage — cost accumulation                                       */
-/* ------------------------------------------------------------------ */
-
-describe("addUsage", () => {
-  it("accumulates cost into target", () => {
-    const target: LifetimeUsage = { input: 100, output: 50, cacheWrite: 10, cost: 5 };
-    addUsage(target, { input: 10, output: 5, cacheWrite: 1, cost: 2 });
-    expect(target).toEqual({ input: 110, output: 55, cacheWrite: 11, cost: 7 });
-  });
-
-  it("handles zero cost delta", () => {
-    const target: LifetimeUsage = { input: 100, output: 50, cacheWrite: 10, cost: 5 };
-    addUsage(target, { input: 10, output: 5, cacheWrite: 1, cost: 0 });
-    expect(target.cost).toBe(5);
-  });
-
-  it("accumulates multiple deltas", () => {
-    const target: LifetimeUsage = { input: 0, output: 0, cacheWrite: 0, cost: 0 };
-    addUsage(target, { input: 100, output: 50, cacheWrite: 10, cost: 2.5 });
-    addUsage(target, { input: 200, output: 100, cacheWrite: 20, cost: 5.0 });
-    addUsage(target, { input: 50, output: 25, cacheWrite: 5, cost: 1.25 });
-    expect(target).toEqual({ input: 350, output: 175, cacheWrite: 35, cost: 8.75 });
-  });
-});
-
-/* ------------------------------------------------------------------ */
-/*  getLifetimeTotal — includes cost                                   */
-/* ------------------------------------------------------------------ */
-
-describe("getLifetimeTotal", () => {
-  it("returns sum of input + output + cacheWrite + cost", () => {
-    const u: LifetimeUsage = { input: 100, output: 50, cacheWrite: 10, cost: 5 };
-    // 100 + 50 + 10 + 5 = 165
-    expect(getLifetimeTotal(u)).toBe(165);
-  });
-
-  it("returns 0 for undefined", () => {
+describe("usage accounting", () => {
+  it("accumulates billable usage but never treats dollars as tokens", () => {
+    const usage: LifetimeUsage = { input: 100, output: 50, cacheWrite: 10, cost: 5 };
+    addUsage(usage, { input: 10, output: 5, cacheWrite: 1, cost: 2 });
+    expect(usage).toEqual({ input: 110, output: 55, cacheWrite: 11, cost: 7 });
+    expect(getLifetimeTotal(usage)).toBe(176);
     expect(getLifetimeTotal(undefined)).toBe(0);
   });
-
-  it("returns 0 when all components are 0", () => {
-    const u: LifetimeUsage = { input: 0, output: 0, cacheWrite: 0, cost: 0 };
-    expect(getLifetimeTotal(u)).toBe(0);
-  });
 });
 
-/* ------------------------------------------------------------------ */
-/*  formatTokens — compact token formatting                            */
-/* ------------------------------------------------------------------ */
-
-describe("formatTokens", () => {
-  it("formats values below 1000 as raw number", () => {
-    expect(formatTokens(0)).toBe("0");
-    expect(formatTokens(500)).toBe("500");
-    expect(formatTokens(999)).toBe("999");
+describe("Pi footer primitives", () => {
+  it("uses Pi token thresholds exactly", () => {
+    expect([
+      formatTokens(999),
+      formatTokens(1_000),
+      formatTokens(9_999),
+      formatTokens(10_000),
+      formatTokens(999_999),
+      formatTokens(1_000_000),
+      formatTokens(9_999_999),
+      formatTokens(10_000_000),
+    ]).toEqual(["999", "1.0k", "10.0k", "10k", "1000k", "1.0M", "10.0M", "10M"]);
   });
 
-  it("formats values >= 1000 with k suffix (1 decimal)", () => {
-    expect(formatTokens(1000)).toBe("1.0k");
-    expect(formatTokens(12300)).toBe("12.3k");
-    expect(formatTokens(100500)).toBe("100.5k");
+  it("formats costs to exactly three decimals", () => {
+    expect([formatCost(0), formatCost(0.008), formatCost(1.23), formatCost(12.3456)])
+      .toEqual(["$0.000", "$0.008", "$1.230", "$12.346"]);
   });
 
-  it("formats values >= 1000000 with M suffix (1 decimal)", () => {
-    expect(formatTokens(1_000_000)).toBe("1.0M");
-    expect(formatTokens(1_200_000)).toBe("1.2M");
-    expect(formatTokens(12_345_678)).toBe("12.3M");
-  });
-
-  it("rounds down (no decimal rounding issues)", () => {
-    // 1234 → 1.234 → 1.2k
-    expect(formatTokens(1234)).toBe("1.2k");
-  });
-
-  it("handles exactly 1 million", () => {
-    expect(formatTokens(1_000_000)).toBe("1.0M");
-  });
-});
-
-/* ------------------------------------------------------------------ */
-/*  formatCost — dollar formatting                                   */
-/* ------------------------------------------------------------------ */
-
-describe("formatCost", () => {
-  it("formats zero as $0.00", () => {
-    expect(formatCost(0)).toBe("$0.00");
-  });
-
-  it("formats small cost with 2 decimal places", () => {
-    expect(formatCost(0.008)).toBe("$0.01");
-  });
-
-  it("formats $1.23", () => {
-    expect(formatCost(1.23)).toBe("$1.23");
-  });
-
-  it("formats $0.01", () => {
-    expect(formatCost(0.01)).toBe("$0.01");
-  });
-
-  it("formats $12.34", () => {
-    expect(formatCost(12.345)).toBe("$12.35");
-  });
-
-  it("formats very small cost as $0.00", () => {
-    expect(formatCost(0.001)).toBe("$0.00");
+  it("reads context/model fallback, auto compaction, and subscription defensively", () => {
+    const session = {
+      getContextUsage: () => ({ percent: null, contextWindow: 272_000 }),
+      model: { provider: "oauth-provider" },
+      autoCompactionEnabled: true,
+      modelRuntime: { isUsingOAuth: (provider: string) => provider === "oauth-provider" },
+    };
+    expect(getSessionUsageSnapshot(session)).toEqual({
+      contextPercent: null,
+      contextWindow: 272_000,
+      autoCompactionEnabled: true,
+      usingSubscription: true,
+    });
+    expect(getSessionUsageSnapshot({ model: { provider: "kimi-coding", contextWindow: 128_000 } }))
+      .toMatchObject({ contextPercent: null, contextWindow: 128_000, usingSubscription: true });
+    expect(getSessionUsageSnapshot({
+      getSessionStats: () => ({ contextUsage: { percent: 70.1 } }),
+    })).toEqual({ contextPercent: 70.1 });
+    expect(getSessionUsageSnapshot({ getContextUsage: () => { throw new Error("mock"); } })).toBeUndefined();
   });
 });

--- a/test/config/config-io.test.ts
+++ b/test/config/config-io.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { join } from "node:path";
+
+const { mockGetAgentDir, mockMkdirSync, mockWriteFileSync, mockRenameSync, mockReadFileSync } = vi.hoisted(() => ({
+  mockGetAgentDir: vi.fn(),
+  mockMkdirSync: vi.fn(),
+  mockWriteFileSync: vi.fn(),
+  mockRenameSync: vi.fn(),
+  mockReadFileSync: vi.fn(),
+}));
+
+vi.mock("@earendil-works/pi-coding-agent", () => ({
+  getAgentDir: mockGetAgentDir,
+}));
+
+vi.mock("node:fs", () => ({
+  mkdirSync: mockMkdirSync,
+  writeFileSync: mockWriteFileSync,
+  renameSync: mockRenameSync,
+  readFileSync: mockReadFileSync,
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("config I/O paths", () => {
+  it("uses Pi's agent directory for config and custom prompts when HOME is unset", async () => {
+    const agentDir = "C:\\Users\\Pi User\\.pi\\agent";
+    vi.stubEnv("HOME", "");
+    mockGetAgentDir.mockReturnValue(agentDir);
+    vi.resetModules();
+
+    const { CUSTOM_PROMPT_PATH, saveConfigAtomic } = await import("../../src/config/config-io.ts");
+    saveConfigAtomic({ agent: {} as any, concurrency: {} as any });
+
+    const configPath = join(agentDir, "subagents-lite.json");
+    expect(mockGetAgentDir).toHaveBeenCalledOnce();
+    expect(CUSTOM_PROMPT_PATH).toBe(join(agentDir, "subagents-lite-prompt.md"));
+    expect(mockMkdirSync).toHaveBeenCalledWith(agentDir, { recursive: true });
+    expect(mockWriteFileSync).toHaveBeenCalledWith(`${configPath}.tmp`, expect.any(String), "utf-8");
+    expect(mockRenameSync).toHaveBeenCalledWith(`${configPath}.tmp`, configPath);
+  });
+});

--- a/test/config/config-io.test.ts
+++ b/test/config/config-io.test.ts
@@ -26,6 +26,26 @@ afterEach(() => {
 });
 
 describe("config I/O paths", () => {
+  it("loads widget visibility settings and supplies their true defaults", async () => {
+    mockGetAgentDir.mockReturnValue("/agent");
+    mockReadFileSync.mockReturnValue(JSON.stringify({
+      agent: { default: null, forceBackground: false },
+      concurrency: { default: 4 },
+    }));
+    vi.resetModules();
+
+    const { loadConfig } = await import("../../src/config/config-io.ts");
+    expect(loadConfig().agent.widgetShowModelThinking).toBe(true);
+    expect(loadConfig().agent.widgetShowStartTime).toBe(true);
+
+    mockReadFileSync.mockReturnValue(JSON.stringify({
+      agent: { default: null, forceBackground: false, widgetShowModelThinking: false, widgetShowStartTime: false },
+      concurrency: { default: 4 },
+    }));
+    expect(loadConfig().agent.widgetShowModelThinking).toBe(false);
+    expect(loadConfig().agent.widgetShowStartTime).toBe(false);
+  });
+
   it("uses Pi's agent directory for config and custom prompts when HOME is unset", async () => {
     const agentDir = "C:\\Users\\Pi User\\.pi\\agent";
     vi.stubEnv("HOME", "");

--- a/test/config/config-store.test.ts
+++ b/test/config/config-store.test.ts
@@ -23,6 +23,11 @@ function defaultConfig(): SubagentsConfig {
       widgetDescLengthCompact: 30,
       widgetCompact: false,
       widgetShortcut: false,
+      widgetShowModelThinking: true,
+      widgetShowStartTime: true,
+      widgetNavHint: true,
+      outputThinkingBufferSize: 0,
+      finishedRetentionMinutes: 10,
       systemPromptMode: "replace",
       includeContextFiles: true,
       disableDefaultAgents: false,
@@ -66,6 +71,8 @@ function widgetStub(): { w: AgentWidget; calls: string[] } {
     setShowCost: (e: boolean) => calls.push(`setShowCost:${e}`),
     setForceCompact: (e: boolean) => calls.push(`setForceCompact:${e}`),
     setWidgetShortcut: (e: boolean) => calls.push(`setWidgetShortcut:${e}`),
+    setShowModelThinking: (e: boolean) => calls.push(`setShowModelThinking:${e}`),
+    setShowStartTime: (e: boolean) => calls.push(`setShowStartTime:${e}`),
     setMaxLines: (n: number) => calls.push(`setMaxLines:${n}`),
     setMaxLinesCompact: (n: number) => calls.push(`setMaxLinesCompact:${n}`),
     setDescLengthFull: (n: number) => calls.push(`setDescLengthFull:${n}`),
@@ -102,13 +109,16 @@ describe("ConfigStore reads", () => {
     expect(store.agent.widgetMaxLinesCompact).toBe(6);
     expect(store.agent.widgetCompact).toBe(false);
     expect(store.agent.widgetShortcut).toBe(false);
+    expect(store.agent.widgetShowModelThinking).toBe(true);
+    expect(store.agent.widgetShowStartTime).toBe(true);
+    expect(store.agent.widgetNavHint).toBe(true);
     expect(store.agent.defaultModel).toBeNull();
     expect(store.agent.finishedRetentionMinutes).toBe(10);
   });
 
   it("returns configured values when present", () => {
     const { io } = memIO({
-      agent: { default: "config/default", forceBackground: true, graceTurns: 9, showCost: true, widgetMaxLines: 20, widgetMaxLinesCompact: 7, widgetCompact: true, widgetShortcut: true },
+      agent: { default: "config/default", forceBackground: true, graceTurns: 9, showCost: true, widgetMaxLines: 20, widgetMaxLinesCompact: 7, widgetCompact: true, widgetShortcut: true, widgetShowModelThinking: false, widgetShowStartTime: false, widgetNavHint: false },
       concurrency: { default: 2 },
     });
     const store = new ConfigStore(io);
@@ -116,8 +126,21 @@ describe("ConfigStore reads", () => {
     expect(store.agent.showCost).toBe(true);
     expect(store.agent.widgetMaxLines).toBe(20);
     expect(store.agent.widgetMaxLinesCompact).toBe(7);
+    expect(store.agent.widgetShowModelThinking).toBe(false);
+    expect(store.agent.widgetShowStartTime).toBe(false);
+    expect(store.agent.widgetNavHint).toBe(false);
     expect(store.concurrency.default).toBe(2);
     expect(store.agent.defaultModel).toBe("config/default");
+  });
+
+  it("clamps loaded widget line limits to at least two", () => {
+    const { io } = memIO({
+      agent: { default: null, forceBackground: false, widgetMaxLines: 1, widgetMaxLinesCompact: 1 },
+      concurrency: { default: 4 },
+    });
+    const store = new ConfigStore(io);
+    expect(store.agent.widgetMaxLines).toBe(2);
+    expect(store.agent.widgetMaxLinesCompact).toBe(2);
   });
 
   it("concurrency providers/models default to {}", () => {
@@ -173,18 +196,24 @@ describe("ConfigStore persisted mutations", () => {
     expect(calls.some(c => c.startsWith("setStatsVisibility:" ))).toBe(true);
   });
 
-  it("setWidgetMaxLines derives compact when unset and syncs the widget", () => {
+  it("clamps widget line setters and derives compact minimum from full minimum", () => {
     const { io, saves } = memIO();
     const { w, calls } = widgetStub();
     const store = new ConfigStore(io);
     store.setDeps({ widget: w });
     calls.length = 0;
 
-    store.mutate.widget.setMaxLines(20);
-    expect(saves[0].agent.widgetMaxLines).toBe(20);
-    expect(saves[0].agent.widgetMaxLinesCompact).toBe(10);
-    expect(calls).toContain("setMaxLines:20");
-    expect(calls).toContain("setMaxLinesCompact:10");
+    store.mutate.widget.setMaxLines(2);
+    expect(saves[0].agent.widgetMaxLines).toBe(2);
+    expect(saves[0].agent.widgetMaxLinesCompact).toBe(2);
+    expect(calls).toContain("setMaxLines:2");
+    expect(calls).toContain("setMaxLinesCompact:2");
+
+    store.mutate.widget.setMaxLines(1);
+    expect(saves[1].agent.widgetMaxLines).toBe(2);
+
+    store.mutate.widget.setMaxLinesCompact(1);
+    expect(saves[2].agent.widgetMaxLinesCompact).toBe(2);
   });
 
   it("setMaxLines does not overwrite an explicitly-set compact value", () => {
@@ -205,7 +234,7 @@ describe("ConfigStore persisted mutations", () => {
     expect(calls).toContain("setForceCompact:true");
   });
 
-  it("setShortcut persists but does not sync widget", () => {
+  it("setShortcut persists and immediately syncs the widget", () => {
     const { io, saves } = memIO();
     const { w, calls } = widgetStub();
     const store = new ConfigStore(io);
@@ -213,7 +242,35 @@ describe("ConfigStore persisted mutations", () => {
     calls.length = 0;
     store.mutate.widget.setShortcut(true);
     expect(saves[0].agent.widgetShortcut).toBe(true);
-    expect(calls.some((c) => c.startsWith("setWidgetShortcut"))).toBe(false);
+    expect(calls).toContain("setWidgetShortcut:true");
+  });
+
+  it("setShowModelThinking persists and immediately syncs the widget", () => {
+    const { io, saves } = memIO();
+    const { w, calls } = widgetStub();
+    const store = new ConfigStore(io);
+    store.setDeps({ widget: w });
+    calls.length = 0;
+
+    store.mutate.widget.setShowModelThinking(false);
+
+    expect(store.agent.widgetShowModelThinking).toBe(false);
+    expect(saves[0].agent.widgetShowModelThinking).toBe(false);
+    expect(calls).toContain("setShowModelThinking:false");
+  });
+
+  it("setShowStartTime persists and immediately syncs the widget", () => {
+    const { io, saves } = memIO();
+    const { w, calls } = widgetStub();
+    const store = new ConfigStore(io);
+    store.setDeps({ widget: w });
+    calls.length = 0;
+
+    store.mutate.widget.setShowStartTime(false);
+
+    expect(store.agent.widgetShowStartTime).toBe(false);
+    expect(saves[0].agent.widgetShowStartTime).toBe(false);
+    expect(calls).toContain("setShowStartTime:false");
   });
 
   it("concurrency setters persist and call manager.setConcurrency", () => {
@@ -297,7 +354,7 @@ describe("ConfigStore model-override clearing", () => {
 
   it("clearAllModelOverrides preserves non-model settings, drops per-type overrides", () => {
     const { io } = memIO({
-      agent: { default: "keep-default", forceBackground: true, graceTurns: 7, showCost: true, widgetMaxLines: 14, Explore: "m1", general: "m2" },
+      agent: { default: "keep-default", forceBackground: true, graceTurns: 7, showCost: true, widgetMaxLines: 14, widgetShowModelThinking: false, widgetShowStartTime: false, Explore: "m1", general: "m2" },
       concurrency: { default: 4 },
     });
     const store = new ConfigStore(io);
@@ -310,6 +367,8 @@ describe("ConfigStore model-override clearing", () => {
     expect(snap.graceTurns).toBe(7);
     expect(snap.showCost).toBe(true);
     expect(snap.widgetMaxLines).toBe(14);
+    expect(snap.widgetShowModelThinking).toBe(false);
+    expect(snap.widgetShowStartTime).toBe(false);
   });
 });
 
@@ -577,7 +636,7 @@ describe("ConfigStore lifecycle", () => {
   });
 
   it("reload re-syncs deps", () => {
-    const { io } = memIO({ agent: { default: null, forceBackground: false, showCost: true, widgetCompact: true }, concurrency: { default: 4 } });
+    const { io } = memIO({ agent: { default: null, forceBackground: false, showCost: true, widgetCompact: true, widgetShowModelThinking: false }, concurrency: { default: 4 } });
     const { w, calls } = widgetStub();
     const store = new ConfigStore(io);
     store.setDeps({ widget: w });
@@ -585,6 +644,7 @@ describe("ConfigStore lifecycle", () => {
     store.reload();
     expect(calls).toContain("setShowCost:true");
     expect(calls).toContain("setForceCompact:true");
+    expect(calls).toContain("setShowModelThinking:false");
   });
 
   it("reload re-syncs retention to manager", () => {
@@ -606,6 +666,17 @@ describe("ConfigStore lifecycle", () => {
     expect(calls).toContain("setShowCost:true");
   });
 
+  it("setDeps applies a known collapsed tools state when shortcut coupling is active", () => {
+    const { io } = memIO({ agent: { default: null, forceBackground: false, widgetShortcut: true }, concurrency: { default: 4 } });
+    const { w, calls } = widgetStub();
+    const store = new ConfigStore(io);
+
+    store.notifyToolsExpanded(false);
+    store.setDeps({ widget: w });
+
+    expect(calls).toContain("setCompactMode:true");
+  });
+
   it("dispose drops deps so mutations no longer sync", () => {
     const { io } = memIO();
     const { w, calls } = widgetStub();
@@ -623,27 +694,46 @@ describe("ConfigStore lifecycle", () => {
 /* ------------------------------------------------------------------ */
 
 describe("ConfigStore notifyToolsExpanded", () => {
-  it("toggles widget compact mode only when shortcut is enabled and compact is off", () => {
+  it("applies the first known tools state and later transitions when shortcut is enabled", () => {
     const { io } = memIO({ agent: { default: null, forceBackground: false, widgetShortcut: true, widgetCompact: false }, concurrency: { default: 4 } });
     const { w, calls } = widgetStub();
     const store = new ConfigStore(io);
     store.setDeps({ widget: w });
-
-    store.notifyToolsExpanded(false); // initial transition from undefined -> ignored
     calls.length = 0;
-    store.notifyToolsExpanded(true); // expanded -> full
-    store.notifyToolsExpanded(false); // collapsed -> compact
+
+    store.notifyToolsExpanded(true);
+    expect(calls).toContain("setCompactMode:false");
+    calls.length = 0;
+    store.notifyToolsExpanded(false);
     expect(calls).toContain("setCompactMode:true");
   });
 
-  it("is a no-op when widgetShortcut is disabled", () => {
+  it("applies a known tools state when shortcut is enabled later", () => {
     const { io } = memIO({ agent: { default: null, forceBackground: false, widgetShortcut: false }, concurrency: { default: 4 } });
     const { w, calls } = widgetStub();
     const store = new ConfigStore(io);
     store.setDeps({ widget: w });
     calls.length = 0;
+
+    store.notifyToolsExpanded(false);
+    store.mutate.widget.setShortcut(true);
+
+    expect(calls).toContain("setWidgetShortcut:true");
+    expect(calls).toContain("setCompactMode:true");
+  });
+
+  it("ends shortcut coupling when shortcut is disabled", () => {
+    const { io } = memIO({ agent: { default: null, forceBackground: false, widgetShortcut: true }, concurrency: { default: 4 } });
+    const { w, calls } = widgetStub();
+    const store = new ConfigStore(io);
+    store.setDeps({ widget: w });
+    store.notifyToolsExpanded(false);
+    store.mutate.widget.setShortcut(false);
+    calls.length = 0;
+
     store.notifyToolsExpanded(true);
     store.notifyToolsExpanded(false);
+
     expect(calls).toHaveLength(0);
   });
 
@@ -656,6 +746,20 @@ describe("ConfigStore notifyToolsExpanded", () => {
     store.notifyToolsExpanded(true);
     store.notifyToolsExpanded(false);
     expect(calls).toHaveLength(0);
+  });
+
+  it("applies a known collapsed tools state when force compact is disabled", () => {
+    const { io } = memIO({ agent: { default: null, forceBackground: false, widgetShortcut: true, widgetCompact: true }, concurrency: { default: 4 } });
+    const { w, calls } = widgetStub();
+    const store = new ConfigStore(io);
+    store.setDeps({ widget: w });
+    store.notifyToolsExpanded(false);
+    calls.length = 0;
+
+    store.mutate.widget.setCompact(false);
+
+    expect(calls).toContain("setForceCompact:false");
+    expect(calls).toContain("setCompactMode:true");
   });
 });
 

--- a/test/events-navigation.test.ts
+++ b/test/events-navigation.test.ts
@@ -72,6 +72,7 @@ vi.mock("../src/agents/agent-manager.js", () => ({
     getAgent() { return undefined; }
     setConcurrency() {}
     getTotalAgentCost() { return 0; }
+    getTotalAgentCount() { return 0; }
     setOnComplete() {}
     dispose() { return Promise.resolve(); }
   },
@@ -111,6 +112,7 @@ vi.mock("../src/ui/format.js", () => ({
 const mockManager: any = {
   listAgents: vi.fn(() => []),
   getTotalAgentCost: vi.fn(() => 0),
+  getTotalAgentCount: vi.fn(() => 0),
 };
 
 const mockWidget: any = {

--- a/test/events-navigation.test.ts
+++ b/test/events-navigation.test.ts
@@ -6,8 +6,19 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { join } from "node:path";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { createNavInputHandler } from "../src/events.js";
+import { createNavInputHandler, scanAndRegisterAgents } from "../src/events.js";
+
+const { mockGetAgentDir, mockSetAgentScanDirs, mockScanAndMerge } = vi.hoisted(() => ({
+  mockGetAgentDir: vi.fn(() => "C:\\Users\\Pi User\\.pi\\agent"),
+  mockSetAgentScanDirs: vi.fn(),
+  mockScanAndMerge: vi.fn(async () => new Map()),
+}));
+
+vi.mock("@earendil-works/pi-coding-agent", () => ({
+  getAgentDir: mockGetAgentDir,
+}));
 
 /* ------------------------------------------------------------------ */
 /*  Mock setup                                                        */
@@ -38,7 +49,8 @@ vi.mock("../src/agents/agent-types.js", () => ({
   }),
   registerAgents: vi.fn(),
   getAvailableTypes: vi.fn(() => []),
-  setAgentScanDirs: vi.fn(),
+  setAgentScanDirs: mockSetAgentScanDirs,
+  scanAndMerge: mockScanAndMerge,
 }));
 
 vi.mock("../src/agents/default-agents.js", () => ({
@@ -116,6 +128,7 @@ const mockWidget: any = {
 };
 
 const mockStore: any = {
+  agent: { disableDefaultAgents: false },
   notifyToolsExpanded: vi.fn(),
 };
 
@@ -148,12 +161,28 @@ describe("navigation key handler (createNavInputHandler)", () => {
     mockManager.listAgents.mockReturnValue([]);
     mockMatchesKey.mockReturnValue(false);
     mockIsKeyRelease.mockReturnValue(false);
+    mockGetAgentDir.mockReturnValue("C:\\Users\\Pi User\\.pi\\agent");
     ctx = {
       ui: {
         getEditorText: vi.fn(() => ""),
         notify: vi.fn(),
       },
     } as unknown as ExtensionContext;
+  });
+
+  it("uses Pi's agent directory for global agents when HOME is unset", async () => {
+    vi.stubEnv("HOME", "");
+    const agentDir = "C:\\Users\\Pi User\\.pi\\agent";
+
+    try {
+      await scanAndRegisterAgents({ cwd: "C:\\work\\project" } as ExtensionContext);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+
+    expect(mockGetAgentDir).toHaveBeenCalledOnce();
+    expect(mockSetAgentScanDirs)
+      .toHaveBeenCalledWith(join(agentDir, "agents"), join("C:\\work\\project", ".pi", "agents"), join("C:\\work\\project", ".agents", "agents"));
   });
 
   describe("key release ignored", () => {

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -7,6 +7,8 @@
  *   - loadExtension: import and invoke the extension factory
  *   - createMockSession: mock agent session for output-file tests
  *   - tempDirFixture: temp directory setup/teardown for filesystem tests
+ *   - canCreateSymlinks: detect whether the current host permits file symlink creation
+ *   - createDirectoryLink / canCreateDirectoryLinks: portable directory-link fixtures
  *   - makeAgentMd: build agent .md content from frontmatter fields
  *   - tempDirWithFiles: create a temp dir with files for scanAgentFilesInDir tests
  *
@@ -79,7 +81,9 @@ export function shellMock(fns: ShellMockFns = {}) {
 import {
   existsSync,
   mkdirSync,
+  mkdtempSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
@@ -277,6 +281,44 @@ export function tempDirFixture(prefix = "subagents-test") {
       }
     },
   };
+}
+
+/** Create a directory link, using a junction on Windows to avoid the symlink privilege. */
+export function createDirectoryLink(target: string, link: string): void {
+  symlinkSync(target, link, process.platform === "win32" ? "junction" : "dir");
+}
+
+/** Return whether this host currently permits creating file symlinks. */
+export function canCreateSymlinks(): boolean {
+  return canCreateLink("file");
+}
+
+/** Return whether this host currently permits creating directory links. */
+export function canCreateDirectoryLinks(): boolean {
+  return canCreateLink("dir");
+}
+
+function canCreateLink(type: "dir" | "file"): boolean {
+  const dir = mkdtempSync(join(tmpdir(), "pi-symlink-capability-"));
+  try {
+    const target = join(dir, "target");
+    if (type === "dir") {
+      mkdirSync(target);
+      createDirectoryLink(target, join(dir, "link"));
+    } else {
+      writeFileSync(target, "target");
+      symlinkSync(target, join(dir, "link"), "file");
+    }
+    return true;
+  } catch (error: unknown) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (["EACCES", "ENOSYS", "ENOTSUP", "EPERM"].includes(code ?? "")) {
+      return false;
+    }
+    throw error;
+  } finally {
+    try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
 }
 
 /* ------------------------------------------------------------------ */

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -58,6 +58,7 @@ export function shellMock(fns: ShellMockFns = {}) {
     listAgents: vi.fn(() => []),
     spawn: vi.fn(),
     getTotalAgentCost: vi.fn(() => 0),
+    getTotalAgentCount: vi.fn(() => 0),
   };
   const pi = fns.pi ?? { sendMessage: vi.fn(), exec: vi.fn() };
   const sessionCtx = fns.sessionCtx ?? { cwd: "/home/test" };

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -228,6 +228,12 @@ describe("Agent tool schema — stealth", () => {
     expect(wtSchema?.description).toBeUndefined();
   });
 
+  it("keeps non-prompt arguments optional", () => {
+    const properties = agentTool()!.parameters.properties;
+    for (const name of ["description", "agent", "run_in_background", "worktree_path"]) {
+      expect(properties[name].optional).toBe(true);
+    }
+  });
 
   it("excludes isolated from schema (config-only, not LLM-controlled)", () => {
     expect(hasParam(agentTool()!.parameters, "isolated")).toBe(false);
@@ -458,7 +464,11 @@ describe("constrained sampling", () => {
     await loadExtension(api.api);
   });
 
-  for (const toolName of ["Agent", "StopAgent", "AgentStatus"]) {
+  it("omits constrainedSampling from Agent so providers can accept its optional arguments", () => {
+    expect(findTool(api, "Agent")!.constrainedSampling).toBeUndefined();
+  });
+
+  for (const toolName of ["StopAgent", "AgentStatus"]) {
     it(`${toolName} has constrainedSampling with json_schema and strict: prefer`, () => {
       const tool = findTool(api, toolName);
       expect(tool).toBeDefined();
@@ -467,7 +477,9 @@ describe("constrained sampling", () => {
         strict: "prefer",
       });
     });
+  }
 
+  for (const toolName of ["Agent", "StopAgent", "AgentStatus"]) {
     it(`${toolName} schema has additionalProperties: false`, () => {
       const tool = findTool(api, toolName);
       expect(tool).toBeDefined();

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -51,6 +51,7 @@ vi.mock("@sinclair/typebox", () => {
 });
 vi.mock("@earendil-works/pi-coding-agent", () => ({
   DynamicBorder: class {},
+  getAgentDir: vi.fn(() => "/home/test/.pi/agent"),
 }));
 
 vi.mock("@earendil-works/pi-tui", () => ({

--- a/test/menu-mock-setup.ts
+++ b/test/menu-mock-setup.ts
@@ -130,6 +130,9 @@ vi.mock("../src/shell.js", () => {
         widgetMaxLinesCompact: a.widgetMaxLinesCompact ?? Math.floor(widgetMaxLines / 2),
         widgetCompact: a.widgetCompact === true,
         widgetShortcut: a.widgetShortcut === true,
+        widgetShowModelThinking: a.widgetShowModelThinking !== false,
+        widgetShowStartTime: a.widgetShowStartTime !== false,
+        widgetNavHint: a.widgetNavHint !== false,
         widgetDescLengthFull: a.widgetDescLengthFull ?? 50,
         widgetDescLengthCompact: a.widgetDescLengthCompact ?? 30,
         systemPromptMode: a.systemPromptMode ?? "replace",
@@ -187,7 +190,7 @@ vi.mock("../src/shell.js", () => {
         clearModelOverride(type: string) { delete mockModules.mockConfig.agent[type]; },
         clearAllModelOverrides() {
           const preserved: Record<string, unknown> = {};
-          for (const key of ['default', 'forceBackground', 'graceTurns', 'showCost', 'showTools', 'showTurns', 'showInput', 'showOutput', 'showContext', 'showTime', 'deltaInputTokens', 'widgetMaxLines', 'widgetMaxLinesCompact', 'widgetDescLengthFull', 'widgetDescLengthCompact', 'widgetCompact', 'widgetShortcut', 'systemPromptMode', 'includeContextFiles', 'defaultThinking', 'defaultMaxTurns', 'loadSkillsImplicitly', 'loadExtensionsImplicitly']) {
+          for (const key of ['default', 'forceBackground', 'graceTurns', 'showCost', 'showTools', 'showTurns', 'showInput', 'showOutput', 'showContext', 'showTime', 'deltaInputTokens', 'widgetMaxLines', 'widgetMaxLinesCompact', 'widgetDescLengthFull', 'widgetDescLengthCompact', 'widgetCompact', 'widgetShortcut', 'widgetShowModelThinking', 'widgetShowStartTime', 'widgetNavHint', 'systemPromptMode', 'includeContextFiles', 'defaultThinking', 'defaultMaxTurns', 'loadSkillsImplicitly', 'loadExtensionsImplicitly', 'disableDefaultAgents', 'outputThinkingBufferSize', 'finishedRetentionMinutes']) {
             const val = mockModules.mockConfig.agent[key];
             if (val != null || key === 'default' || key === 'forceBackground') {
               preserved[key] = val;
@@ -221,6 +224,9 @@ vi.mock("../src/shell.js", () => {
         setDescLengthFull(n: number) { mockModules.mockConfig.agent.widgetDescLengthFull = n; },
         setDescLengthCompact(n: number) { mockModules.mockConfig.agent.widgetDescLengthCompact = n; },
         setShortcut(enabled: boolean) { mockModules.mockConfig.agent.widgetShortcut = enabled; },
+        setShowModelThinking(enabled: boolean) { mockModules.mockConfig.agent.widgetShowModelThinking = enabled; },
+        setShowStartTime(enabled: boolean) { mockModules.mockConfig.agent.widgetShowStartTime = enabled; },
+        setNavHint(enabled: boolean) { mockModules.mockConfig.agent.widgetNavHint = enabled; },
       },
       concurrency: {
         setDefault(n: number) { mockModules.mockConfig.concurrency.default = n; },

--- a/test/menu-mock-setup.ts
+++ b/test/menu-mock-setup.ts
@@ -81,6 +81,18 @@ vi.mock("../src/ui/searchable-select.js", () => ({
 
 vi.mock("../src/ui/format.js", () => ({
   getDisplayName: vi.fn((t: string) => t),
+  getAgentStatusDisplay: vi.fn((status: string) => {
+    const displays: Record<string, { icon: string; color: string }> = {
+      running: { icon: "◈", color: "accent" },
+      queued: { icon: "◇", color: "dim" },
+      completed: { icon: "✓", color: "success" },
+      turn_limited: { icon: "✓", color: "warning" },
+      stopped: { icon: "■", color: "dim" },
+      error: { icon: "✗", color: "error" },
+      aborted: { icon: "✗", color: "error" },
+    };
+    return displays[status];
+  }),
   truncateDesc: vi.fn((t: string) => t),
 }));
 

--- a/test/prompt/skill-loader.test.ts
+++ b/test/prompt/skill-loader.test.ts
@@ -21,17 +21,18 @@ import type { AgentConfig, EnvInfo } from "../../src/types.ts";
 import type { Skill } from "@earendil-works/pi-coding-agent";
 import { createSkillDir, createFlatSkill } from "../fixtures.ts";
 
-const { mockLoadSkills, mockLoadSkillsFromDir, mockFormatSkillsForPrompt } = vi.hoisted(() => ({
+const { mockLoadSkills, mockLoadSkillsFromDir, mockFormatSkillsForPrompt, mockGetAgentDir } = vi.hoisted(() => ({
   mockLoadSkills: vi.fn(),
   mockLoadSkillsFromDir: vi.fn(),
   mockFormatSkillsForPrompt: vi.fn(),
+  mockGetAgentDir: vi.fn(() => "C:\\Users\\Pi User\\.pi\\agent"),
 }));
 
 vi.mock("@earendil-works/pi-coding-agent", () => ({
   loadSkills: mockLoadSkills,
   loadSkillsFromDir: mockLoadSkillsFromDir,
   formatSkillsForPrompt: mockFormatSkillsForPrompt,
-  getAgentDir: vi.fn(() => "/fake/.pi/agent"),
+  getAgentDir: mockGetAgentDir,
 }));
 
 let tmpDir: string;
@@ -61,6 +62,7 @@ beforeEach(() => {
   mockLoadSkills.mockReturnValue({ skills: [], diagnostics: [] });
   mockLoadSkillsFromDir.mockReturnValue({ skills: [], diagnostics: [] });
   mockFormatSkillsForPrompt.mockReturnValue("");
+  mockGetAgentDir.mockReturnValue("C:\\Users\\Pi User\\.pi\\agent");
 });
 
 afterEach(() => {
@@ -85,6 +87,20 @@ describe("loadAllSkills", () => {
       cwd: tmpDir,
       includeDefaults: true,
     }));
+  });
+
+  it("uses Pi's agent directory for default skills when HOME is unset", () => {
+    vi.stubEnv("HOME", "");
+    const agentDir = "C:\\Users\\Pi User\\.pi\\agent";
+
+    try {
+      loadAllSkills(tmpDir);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+
+    expect(mockGetAgentDir).toHaveBeenCalledOnce();
+    expect(mockLoadSkills).toHaveBeenCalledWith(expect.objectContaining({ agentDir }));
   });
 
   it("loads ancestor .agents/skills via loadSkillsFromDir", () => {

--- a/test/spawn/spawn-coordinator.test.ts
+++ b/test/spawn/spawn-coordinator.test.ts
@@ -72,6 +72,7 @@ function makeMockManager() {
     abort: vi.fn(() => true),
     steer: vi.fn(async () => true),
     getTotalAgentCost: vi.fn(() => 0),
+    getTotalAgentCount: vi.fn(() => 0),
     dispose: vi.fn(),
     onComplete: undefined as any,
     onStart: undefined as any,

--- a/test/spawn/worktree-validator.test.ts
+++ b/test/spawn/worktree-validator.test.ts
@@ -14,12 +14,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   existsSync,
   mkdirSync,
-  symlinkSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { canCreateDirectoryLinks, createDirectoryLink } from "../fixtures.ts";
 import {
   validateWorktreePath,
   WORKTREE_VALIDATION_ERRORS,
@@ -28,6 +28,9 @@ import {
 } from "../../src/spawn/worktree-validator.js";
 
 // ── helpers ──────────────────────────────────────────────────────
+
+const itWithDirectoryLinkSupport = it.skipIf(!canCreateDirectoryLinks());
+const toForwardSlashPath = (filePath: string) => filePath.replace(/\\/g, "/");
 
 function makePi(
   gitCommonDirResults: Map<string, string | null>,
@@ -109,8 +112,8 @@ describe("validateWorktreePath", () => {
 
     expect(result.ok).toBe(true);
     const success = result as WorktreeValidationSuccess;
-    expect(success.resolvedPath).toBe(worktreePath);
-    expect(success.worktreeRoot).toBe(worktreePath);
+    expect(success.resolvedPath).toBe(toForwardSlashPath(worktreePath));
+    expect(success.worktreeRoot).toBe(toForwardSlashPath(worktreePath));
     expect(success.label).toBe("feature");
   });
 
@@ -130,7 +133,7 @@ describe("validateWorktreePath", () => {
 
     expect(result.ok).toBe(true);
     const success = result as WorktreeValidationSuccess;
-    expect(success.resolvedPath).toBe(mainCheckout);
+    expect(success.resolvedPath).toBe(toForwardSlashPath(mainCheckout));
   });
 
   it("returns worktree root and non-empty label on success", async () => {
@@ -172,7 +175,7 @@ describe("validateWorktreePath", () => {
 
     expect(result.ok).toBe(true);
     const success = result as WorktreeValidationSuccess;
-    expect(success.resolvedPath).toBe(absolutePath);
+    expect(success.resolvedPath).toBe(toForwardSlashPath(absolutePath));
   });
 
   it("resolves ./wt/feature style relative path", async () => {
@@ -192,7 +195,7 @@ describe("validateWorktreePath", () => {
 
     expect(result.ok).toBe(true);
     const success = result as WorktreeValidationSuccess;
-    expect(success.resolvedPath).toBe(absolutePath);
+    expect(success.resolvedPath).toBe(toForwardSlashPath(absolutePath));
   });
 
   it("resolves parent-relative paths (../wt/feature)", async () => {
@@ -212,7 +215,7 @@ describe("validateWorktreePath", () => {
 
     expect(result.ok).toBe(true);
     const success = result as WorktreeValidationSuccess;
-    expect(success.resolvedPath).toBe(absolutePath);
+    expect(success.resolvedPath).toBe(toForwardSlashPath(absolutePath));
   });
 
   // ── label computation ─────────────────────────────────────────
@@ -259,7 +262,7 @@ describe("validateWorktreePath", () => {
     expect(result.ok).toBe(true);
     const success = result as WorktreeValidationSuccess;
     expect(success.label).toBe("feature/packages/web");
-    expect(success.worktreeRoot).toBe(worktreeRoot);
+    expect(success.worktreeRoot).toBe(toForwardSlashPath(worktreeRoot));
   });
 
   it("label uses forward slashes even for Windows-style relative paths", async () => {
@@ -445,13 +448,13 @@ describe("validateWorktreePath", () => {
 
   // ── symlink resolution ────────────────────────────────────────
 
-  it("resolves symlinks before validation", async () => {
+  itWithDirectoryLinkSupport("resolves symlinks before validation", async () => {
     const parentCwd = join(tmpDir, "parent");
     const realPath = join(tmpDir, "real-feature");
     const symlinkPath = join(tmpDir, "link-to-feature");
     mkdirSync(parentCwd, { recursive: true });
     mkdirSync(realPath, { recursive: true });
-    symlinkSync(realPath, symlinkPath);
+    createDirectoryLink(realPath, symlinkPath);
 
     const commonDir = join(tmpDir, "shared.git");
     const gitResults = new Map<string, string | null>([
@@ -463,16 +466,16 @@ describe("validateWorktreePath", () => {
 
     expect(result.ok).toBe(true);
     const success = result as WorktreeValidationSuccess;
-    expect(success.resolvedPath).toBe(realPath);
+    expect(success.resolvedPath).toBe(toForwardSlashPath(realPath));
   });
 
-  it("rejects a symlink whose target is in a different repo", async () => {
+  itWithDirectoryLinkSupport("rejects a symlink whose target is in a different repo", async () => {
     const parentCwd = join(tmpDir, "parent");
     const otherRepoPath = join(tmpDir, "other-repo-dir");
     const symlinkPath = join(tmpDir, "sneaky-link");
     mkdirSync(parentCwd, { recursive: true });
     mkdirSync(otherRepoPath, { recursive: true });
-    symlinkSync(otherRepoPath, symlinkPath);
+    createDirectoryLink(otherRepoPath, symlinkPath);
 
     const gitResults = new Map<string, string | null>([
       [parentCwd, join(tmpDir, "repo-a", ".git")],

--- a/test/ui/agent-widget-navigation.test.ts
+++ b/test/ui/agent-widget-navigation.test.ts
@@ -31,6 +31,7 @@ vi.mock("../../src/agents/agent-types.js", () => ({
 
 vi.mock("@earendil-works/pi-tui", () => ({
   truncateToWidth: (text: string, width: number) => text,
+  visibleWidth: (text: string) => text.length,
 }));
 
 function makeMockManager(agents: any[], totalAgentCost = 0): AgentManager {

--- a/test/ui/agent-widget-navigation.test.ts
+++ b/test/ui/agent-widget-navigation.test.ts
@@ -283,20 +283,43 @@ describe("navigation roster", () => {
     widget = new AgentWidget(manager, (id) => activity.get(id));
   });
 
-  it("orders navigation as running, queued, then finished", () => {
+  it("orders navigation globally by startedAt across statuses", () => {
     const finished = makeFinishedAgent("f1");
+    finished.lifecycle.startedAt = new Date(2024, 0, 2, 9, 1).getTime();
     const running = makeRunningAgent("r1");
+    running.lifecycle.startedAt = new Date(2024, 0, 2, 9, 2).getTime();
     activity.set("r1", makeActivity("r1"));
     const queued = makeQueuedAgent("q1");
+    queued.lifecycle.startedAt = new Date(2024, 0, 2, 9, 3).getTime();
     (manager as any).listAgents = () => [finished, running, queued];
 
     widget.navActivate();
 
+    expect(widget.navSelect()?.id).toBe("q1");
+    widget.navDown();
     expect(widget.navSelect()?.id).toBe("r1");
     widget.navDown();
+    expect(widget.navSelect()?.id).toBe("f1");
+  });
+
+  it("preserves manager order for equal startedAt values across statuses", () => {
+    const startedAt = new Date(2024, 0, 2, 9, 3).getTime();
+    const queued = makeQueuedAgent("q1");
+    queued.lifecycle.startedAt = startedAt;
+    const finished = makeFinishedAgent("f1");
+    finished.lifecycle.startedAt = startedAt;
+    const running = makeRunningAgent("r1");
+    running.lifecycle.startedAt = startedAt;
+    activity.set(running.id, makeActivity(running.id));
+    (manager as any).listAgents = () => [queued, finished, running];
+
+    widget.navActivate();
+
     expect(widget.navSelect()?.id).toBe("q1");
     widget.navDown();
     expect(widget.navSelect()?.id).toBe("f1");
+    widget.navDown();
+    expect(widget.navSelect()?.id).toBe("r1");
   });
 
   it("queued agents expand to individual rows during navigation", () => {
@@ -311,14 +334,15 @@ describe("navigation roster", () => {
     expect(widget.highlightedIndex()).toBe(1);
   });
 
-  it("queued agents aggregate when navigation is inactive", () => {
+  it("queued agents remain individual when navigation is inactive", () => {
     const q1 = makeQueuedAgent("q1");
     const q2 = makeQueuedAgent("q2");
     (manager as any).listAgents = () => [q1, q2];
 
-    // Without nav active, queued agents render as "2 queued" block
     const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
-    expect(lines.some((l: string) => l.includes("2 queued"))).toBe(true);
+    expect(lines.some((l: string) => l.includes("Queued agent q1"))).toBe(true);
+    expect(lines.some((l: string) => l.includes("Queued agent q2"))).toBe(true);
+    expect(lines.some((l: string) => l.includes("2 queued"))).toBe(false);
   });
 });
 
@@ -441,6 +465,25 @@ describe("overflow with navigation", () => {
     manager = makeMockManager([]);
     activity = new Map();
     widget = new AgentWidget(manager, (id) => activity.get(id));
+  });
+
+  it("keeps a pinned multi-line block within widgetMaxLines by trimming continuations", () => {
+    widget.setMaxLines(3);
+    const pinned = makeRunningAgent("pinned");
+    pinned.display.outputFile = "/tmp/pinned.log";
+    const other = makeFinishedAgent("other");
+    activity.set(pinned.id, makeActivity(pinned.id));
+    (manager as any).listAgents = () => [pinned, other];
+
+    widget.navActivate();
+
+    const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
+    const pinnedHeader = lines.find((line: string) => line.includes("Running agent pinned"));
+
+    expect(lines.length).toBeLessThanOrEqual(3);
+    expect(pinnedHeader).toContain("→");
+    expect(lines.some((line: string) => line.includes("tail -f /tmp/pinned.log"))).toBe(false);
+    expect(lines.some((line: string) => line.includes("more"))).toBe(true);
   });
 
   it("pinned block appears when navigating to a hidden agent", () => {

--- a/test/ui/agent-widget-navigation.test.ts
+++ b/test/ui/agent-widget-navigation.test.ts
@@ -34,12 +34,13 @@ vi.mock("@earendil-works/pi-tui", () => ({
   visibleWidth: (text: string) => text.length,
 }));
 
-function makeMockManager(agents: any[], totalAgentCost = 0): AgentManager {
+function makeMockManager(agents: any[], totalAgentCost = 0, totalAgentCount = agents.length): AgentManager {
   return {
     listAgents: () => agents,
     getAgent: () => undefined,
     setConcurrency: () => {},
     getTotalAgentCost: () => totalAgentCost,
+    getTotalAgentCount: () => totalAgentCount,
   } as any as AgentManager;
 }
 

--- a/test/ui/agent-widget-navigation.test.ts
+++ b/test/ui/agent-widget-navigation.test.ts
@@ -3,7 +3,7 @@
  *
  * Covers:
  *   - Navigation state machine (activate, up, down, select, deactivate)
- *   - Roster building (finished, running, queued)
+ *   - Roster building (running, queued, finished)
  *   - Rendering with `>` marker and heading hint text
  *   - Queued agent expansion during navigation
  *   - Editor focus detection
@@ -151,7 +151,7 @@ describe("navigation state machine", () => {
 
       widget.navActivate();
       expect(widget.isNavActive()).toBe(true);
-      // Index 0 = first finished agent
+      // Index 0 = first running agent
       expect(widget.highlightedIndex()).toBe(0);
     });
 
@@ -170,10 +170,10 @@ describe("navigation state machine", () => {
       activity.set("r1", makeActivity("r1"));
       (manager as any).listAgents = () => [finished, running];
 
-      widget.navActivate(); // highlights index 0 (first finished)
+      widget.navActivate(); // highlights index 0 (first running)
       expect(widget.highlightedIndex()).toBe(0);
 
-      widget.navDown(); // moves to running agent
+      widget.navDown(); // moves to finished agent
       expect(widget.highlightedIndex()).toBe(1);
     });
 
@@ -198,7 +198,7 @@ describe("navigation state machine", () => {
       widget.navDown(); // index 1 (running)
       expect(widget.highlightedIndex()).toBe(1);
 
-      widget.navUp(); // back to finished
+      widget.navUp(); // back to running
       expect(widget.highlightedIndex()).toBe(0);
     });
 
@@ -283,7 +283,7 @@ describe("navigation roster", () => {
     widget = new AgentWidget(manager, (id) => activity.get(id));
   });
 
-  it("includes finished at index 0, then running, queued", () => {
+  it("orders navigation as running, queued, then finished", () => {
     const finished = makeFinishedAgent("f1");
     const running = makeRunningAgent("r1");
     activity.set("r1", makeActivity("r1"));
@@ -292,12 +292,11 @@ describe("navigation roster", () => {
 
     widget.navActivate();
 
-    // Roster: finished(0), running(1), queued(2)
-    expect(widget.highlightedIndex()).toBe(0); // first agent
-    widget.navDown(); // running
-    expect(widget.highlightedIndex()).toBe(1);
-    widget.navDown(); // queued
-    expect(widget.highlightedIndex()).toBe(2);
+    expect(widget.navSelect()?.id).toBe("r1");
+    widget.navDown();
+    expect(widget.navSelect()?.id).toBe("q1");
+    widget.navDown();
+    expect(widget.navSelect()?.id).toBe("f1");
   });
 
   it("queued agents expand to individual rows during navigation", () => {

--- a/test/ui/agent-widget.test.ts
+++ b/test/ui/agent-widget.test.ts
@@ -273,6 +273,29 @@ describe("widget rendering format", () => {
       expect(line).not.toContain("[dim:");
     });
 
+    it("separates every running and finished stats group with two spaces", () => {
+      const running = makeRunningAgent("running");
+      const finished = makeFinishedAgent("finished");
+      for (const agent of [running, finished]) {
+        agent.stats.toolUses = 20;
+        agent.stats.turnCount = 6;
+        agent.stats.lifetimeUsage = { input: 1000, output: 500, cacheWrite: 0, cost: 0 };
+      }
+      activity.set(running.id, makeActivity(running.id));
+      (manager as any).listAgents = () => [running, finished];
+
+      const lines = (widget as any).renderWidget(makeMockTUI(), makePlainTheme());
+      const statsRows = lines.filter((line: string) => line.includes("20⚙︎"));
+
+      expect(statsRows).toHaveLength(2);
+      for (const row of statsRows) {
+        expect(row).toContain("20⚙︎  6⟳  ↑1.0k ↓500");
+        expect(row).toMatch(/↑1\.0k ↓500  (?:\d+m(?: \d+s)?|\d+s)/);
+        expect(row).not.toContain("20⚙︎ ·");
+        expect(row).not.toContain("6⟳ ·");
+      }
+    });
+
     it("preserves an error stat color and reapplies text after its ANSI foreground reset", () => {
       const agent = makeRunningAgent("a1");
       agent.stats.contextPercent = 90.1;
@@ -288,7 +311,7 @@ describe("widget rendering format", () => {
       const statsLine = (widget as any).buildStatsLine(agent, ansiTheme);
 
       expect(statsLine).toContain("\u001b[31m90.1%/272k\u001b[39m");
-      expect(statsLine).toContain("\u001b[31m90.1%/272k\u001b[39m\u001b[97m · ");
+      expect(statsLine).toContain("\u001b[31m90.1%/272k\u001b[39m\u001b[97m  ");
     });
   });
 

--- a/test/ui/agent-widget.test.ts
+++ b/test/ui/agent-widget.test.ts
@@ -34,12 +34,13 @@ vi.mock("@earendil-works/pi-tui", async (importOriginal) => {
   };
 });
 
-function makeMockManager(agents: any[], totalAgentCost = 0): AgentManager {
+function makeMockManager(agents: any[], totalAgentCost = 0, totalAgentCount = agents.length): AgentManager {
   return {
     listAgents: () => agents,
     getAgent: () => undefined,
     setConcurrency: () => {},
     getTotalAgentCost: () => totalAgentCost,
+    getTotalAgentCount: () => totalAgentCount,
     // other methods not used by widget
   } as any as AgentManager;
 }
@@ -552,13 +553,13 @@ describe("finished agent status icons", () => {
 describe("status bar format", () => {
   it("uses Pi's dim token and restyles status text after widget invalidation", () => {
     const uiCtx = { theme: makeMockTheme(), setStatus: vi.fn(), setWidget: vi.fn() };
-    const widget = new AgentWidget(makeMockManager([]), () => undefined);
+    const widget = new AgentWidget(makeMockManager([], 0, 1), () => undefined);
     widget.setUICtx(uiCtx);
     (widget as any).manager.listAgents = () => [makeRunningAgent("a1")];
 
     widget.update();
 
-    expect(uiCtx.setStatus).toHaveBeenCalledWith("subagents", "[dim:1 agent]");
+    expect(uiCtx.setStatus).toHaveBeenCalledWith("subagents", "[dim:1 active · 1 agent total]");
 
     uiCtx.theme = {
       fg: (color: string, text: string) => `[new-${color}:${text}]`,
@@ -567,13 +568,13 @@ describe("status bar format", () => {
     const widgetFactory = (uiCtx.setWidget as any).mock.calls[0][1];
     widgetFactory(makeMockTUI(), makeMockTheme()).invalidate();
 
-    expect(uiCtx.setStatus).toHaveBeenLastCalledWith("subagents", "[new-dim:1 agent]");
+    expect(uiCtx.setStatus).toHaveBeenLastCalledWith("subagents", "[new-dim:1 active · 1 agent total]");
   });
 
-  it("shows 'N agents: $cost' format with running agents", () => {
+  it("shows active and session-total counts with running-agent cost", () => {
     const uiCtx = { setStatus: vi.fn(), setWidget: vi.fn() };
     const activity = new Map();
-    const manager = makeMockManager([], 0);
+    const manager = makeMockManager([], 0, 10);
     const widget = new AgentWidget(manager, (id) => activity.get(id));
     widget.setShowCost(true);
     widget.setUICtx(uiCtx);
@@ -585,41 +586,65 @@ describe("status bar format", () => {
     (manager as any).listAgents = () => [a1, a2];
     widget.update();
 
-    expect(uiCtx.setStatus).toHaveBeenCalledWith("subagents", expect.stringMatching(/^2 agents: \$0\.\d+$/));
+    expect(uiCtx.setStatus).toHaveBeenCalledWith("subagents", expect.stringMatching(/^2 active · 10 agents total: \$0\.\d+$/));
   });
 
-  it("shows finished-agent count and cost when no running/queued agents exist", () => {
+  it("shows only the session total when no agents are active", () => {
     const uiCtx = { setStatus: vi.fn(), setWidget: vi.fn() };
     const activity = new Map();
-    const manager = makeMockManager([], 0.01);
+    const manager = makeMockManager([], 0.01, 10);
     const widget = new AgentWidget(manager, (id) => activity.get(id));
     widget.setShowCost(true);
     widget.setUICtx(uiCtx);
 
-    // Only finished agents, no running/queued
+    // One retained finished record represents a session that has had ten agents.
     const finished = makeFinishedAgent("f1");
     (manager as any).listAgents = () => [finished];
     widget.update();
 
-    expect(uiCtx.setStatus).toHaveBeenCalledWith("subagents", expect.stringMatching(/^1 finished agent: \$0\.\d+$/));
+    expect(uiCtx.setStatus).toHaveBeenCalledWith("subagents", "10 agents total: $0.010");
   });
 
-  it("reports finished agents separately from active agents", () => {
+  it("uses the session total instead of the retained finished-agent count", () => {
     const uiCtx = { setStatus: vi.fn(), setWidget: vi.fn() };
-    const manager = makeMockManager([]);
+    const manager = makeMockManager([], 0, 10);
     const widget = new AgentWidget(manager, () => undefined);
     widget.setUICtx(uiCtx);
 
     (manager as any).listAgents = () => [makeRunningAgent("running"), makeFinishedAgent("finished-1"), makeFinishedAgent("finished-2")];
     widget.update();
 
-    expect(uiCtx.setStatus).toHaveBeenCalledWith("subagents", "1 agent · 2 finished agents");
+    expect(uiCtx.setStatus).toHaveBeenCalledWith("subagents", "1 active · 10 agents total");
   });
 
-  it("shows 'N agents' without cost when cost is zero", () => {
+  it("retains the session summary when retention removes the last record", () => {
+    let statusText: string | undefined;
+    const uiCtx = {
+      setStatus: vi.fn((_key: string, text: string | undefined) => { statusText = text; }),
+      setWidget: vi.fn(),
+    };
+    const manager = makeMockManager([], 0.01, 10);
+    const widget = new AgentWidget(manager, () => undefined);
+    widget.setShowCost(true);
+    widget.setUICtx(uiCtx);
+
+    let agents = [makeFinishedAgent("finished")];
+    (manager as any).listAgents = () => agents;
+    widget.update();
+
+    agents = [];
+    widget.update();
+
+    expect(statusText).toBe("10 agents total: $0.010");
+    expect(uiCtx.setStatus).not.toHaveBeenCalledWith("subagents", undefined);
+    expect(uiCtx.setStatus).toHaveBeenCalledTimes(1);
+    expect(uiCtx.setWidget).toHaveBeenLastCalledWith("agents", undefined);
+  });
+
+  it("shows active and total counts without cost when cost is zero", () => {
     const uiCtx = { setStatus: vi.fn(), setWidget: vi.fn() };
     const activity = new Map();
-    const manager = makeMockManager([], 0);
+    const manager = makeMockManager([], 0, 1);
     const widget = new AgentWidget(manager, (id) => activity.get(id));
     widget.setShowCost(true);
     widget.setUICtx(uiCtx);
@@ -629,7 +654,7 @@ describe("status bar format", () => {
     (manager as any).listAgents = () => [agent];
     widget.update();
 
-    expect(uiCtx.setStatus).toHaveBeenCalledWith("subagents", expect.stringMatching(/^1 agent$/));
+    expect(uiCtx.setStatus).toHaveBeenCalledWith("subagents", "1 active · 1 agent total");
   });
 });
 
@@ -645,7 +670,7 @@ describe("status bar cost from accumulator", () => {
     };
     activity = new Map();
     // No running agents, but totalAgentCost is $1.23 (from evicted agents)
-    manager = makeMockManager([], 1.23);
+    manager = makeMockManager([], 1.23, 2);
     widget = new AgentWidget(manager, (id) => activity.get(id));
     widget.setShowCost(true);
     widget.setUICtx(uiCtx);
@@ -667,7 +692,7 @@ describe("status bar cost from accumulator", () => {
     };
     activity = new Map();
     // Running agent with $0 cost, but session accumulator has $2.50
-    manager = makeMockManager([], 2.50);
+    manager = makeMockManager([], 2.50, 2);
     widget = new AgentWidget(manager, (id) => activity.get(id));
     widget.setShowCost(true);
     widget.setUICtx(uiCtx);
@@ -687,7 +712,7 @@ describe("status bar cost from accumulator", () => {
       setWidget: vi.fn(),
     };
     activity = new Map();
-    manager = makeMockManager([], 1.50);
+    manager = makeMockManager([], 1.50, 1);
     widget = new AgentWidget(manager, (id) => activity.get(id));
     widget.setShowCost(false);
     widget.setUICtx(uiCtx);

--- a/test/ui/agent-widget.test.ts
+++ b/test/ui/agent-widget.test.ts
@@ -374,29 +374,129 @@ describe("widget rendering format", () => {
   });
 
   describe("mixed agent statuses", () => {
-    it("renders running, queued, then finished while preserving each group's order", () => {
+    it("renders one globally newest-first list regardless of status", () => {
+      const base = new Date(2024, 0, 2, 9, 0).getTime();
       const newerRunning = makeRunningAgent("r-new");
       newerRunning.display.description = "Newer running";
+      newerRunning.lifecycle.startedAt = base + 3_000;
       const olderRunning = makeRunningAgent("r-old");
       olderRunning.display.description = "Older running";
+      olderRunning.lifecycle.startedAt = base;
       const queued = makeQueuedAgent("q1");
+      queued.lifecycle.startedAt = base + 2_000;
       const finished = makeFinishedAgent("f1");
+      finished.lifecycle.startedAt = base + 1_000;
       activity.set(newerRunning.id, makeActivity(newerRunning.id));
       activity.set(olderRunning.id, makeActivity(olderRunning.id));
-      // The manager provides each status group newest-first, interleaved by status.
-      (manager as any).listAgents = () => [finished, newerRunning, queued, olderRunning];
+      // Deliberately interleave statuses and timestamps from the manager.
+      (manager as any).listAgents = () => [finished, olderRunning, queued, newerRunning];
 
       const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
       const runningNewIndex = lines.findIndex((line: string) => line.includes("Newer running"));
-      const runningOldIndex = lines.findIndex((line: string) => line.includes("Older running"));
-      const queuedIndex = lines.findIndex((line: string) => line.includes("1 queued"));
+      const queuedIndex = lines.findIndex((line: string) => line.includes("Test agent q1"));
       const finishedIndex = lines.findIndex((line: string) => line.includes("Finished agent f1"));
+      const runningOldIndex = lines.findIndex((line: string) => line.includes("Older running"));
 
       expect(runningNewIndex).toBeGreaterThan(0);
-      expect(runningOldIndex).toBeGreaterThan(runningNewIndex);
-      expect(queuedIndex).toBeGreaterThan(runningOldIndex);
+      expect(queuedIndex).toBeGreaterThan(runningNewIndex);
       expect(finishedIndex).toBeGreaterThan(queuedIndex);
+      expect(runningOldIndex).toBeGreaterThan(finishedIndex);
     });
+  });
+
+  it("preserves manager order for equal startedAt values across statuses", () => {
+    const startedAt = new Date(2024, 0, 2, 9, 0).getTime();
+    const queued = makeQueuedAgent("queued");
+    queued.lifecycle.startedAt = startedAt;
+    const finished = makeFinishedAgent("finished");
+    finished.lifecycle.startedAt = startedAt;
+    const running = makeRunningAgent("running");
+    running.lifecycle.startedAt = startedAt;
+    activity.set(running.id, makeActivity(running.id));
+    (manager as any).listAgents = () => [queued, finished, running];
+
+    const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
+    const queuedIndex = lines.findIndex((line: string) => line.includes("Test agent queued"));
+    const finishedIndex = lines.findIndex((line: string) => line.includes("Finished agent finished"));
+    const runningIndex = lines.findIndex((line: string) => line.includes("Test agent running"));
+
+    expect(queuedIndex).toBeGreaterThan(0);
+    expect(finishedIndex).toBeGreaterThan(queuedIndex);
+    expect(runningIndex).toBeGreaterThan(finishedIndex);
+  });
+
+  it("places a fixed local HH:MM start time directly after every status symbol", () => {
+    const running = makeRunningAgent("running");
+    running.lifecycle.startedAt = new Date(2024, 0, 2, 3, 4).getTime();
+    const queued = makeQueuedAgent("queued");
+    queued.lifecycle.startedAt = new Date(2024, 0, 2, 3, 5).getTime();
+    const finished = makeFinishedAgent("finished");
+    finished.lifecycle.startedAt = new Date(2024, 0, 2, 3, 6).getTime();
+    activity.set(running.id, makeActivity(running.id));
+    (manager as any).listAgents = () => [running, queued, finished];
+
+    const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
+
+    expect(lines.find((line: string) => line.includes("Test agent running"))).toContain("[accent:⠋] [text:03:04]");
+    expect(lines.find((line: string) => line.includes("Test agent queued"))).toContain("[dim:◇] [dim:03:05]");
+    expect(lines.find((line: string) => line.includes("Finished agent finished"))).toContain("[success:✓] [dim:03:06]");
+  });
+
+  it("hides local start time for running, queued, and finished rows when disabled", () => {
+    const running = makeRunningAgent("running");
+    running.lifecycle.startedAt = new Date(2024, 0, 2, 3, 4).getTime();
+    const queued = makeQueuedAgent("queued");
+    queued.lifecycle.startedAt = new Date(2024, 0, 2, 3, 5).getTime();
+    const finished = makeFinishedAgent("finished");
+    finished.lifecycle.startedAt = new Date(2024, 0, 2, 3, 6).getTime();
+    activity.set(running.id, makeActivity(running.id));
+    (manager as any).listAgents = () => [running, queued, finished];
+    widget.setShowStartTime(false);
+
+    const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme()).join("\n");
+
+    expect(lines).not.toContain("03:04");
+    expect(lines).not.toContain("03:05");
+    expect(lines).not.toContain("03:06");
+  });
+
+  it("applies the start-time setting in compact mode for every status", () => {
+    const running = makeRunningAgent("running");
+    running.lifecycle.startedAt = new Date(2024, 0, 2, 3, 4).getTime();
+    const queued = makeQueuedAgent("queued");
+    queued.lifecycle.startedAt = new Date(2024, 0, 2, 3, 5).getTime();
+    const finished = makeFinishedAgent("finished");
+    finished.lifecycle.startedAt = new Date(2024, 0, 2, 3, 6).getTime();
+    activity.set(running.id, makeActivity(running.id));
+    (manager as any).listAgents = () => [running, queued, finished];
+    widget.setWidgetShortcut(true);
+    widget.setCompactMode(true);
+
+    const shown = (widget as any).renderWidget(makeMockTUI(), makeMockTheme()).join("\n");
+    expect(shown).toContain("03:04");
+    expect(shown).toContain("03:05");
+    expect(shown).toContain("03:06");
+
+    widget.setShowStartTime(false);
+    const hidden = (widget as any).renderWidget(makeMockTUI(), makeMockTheme()).join("\n");
+    expect(hidden).not.toContain("03:04");
+    expect(hidden).not.toContain("03:05");
+    expect(hidden).not.toContain("03:06");
+  });
+
+  it("returns the six start-time columns to descriptions on narrow terminals", () => {
+    const agent = makeRunningAgent("narrow");
+    const description = "abcdefghijklmnopqrstuvwxyz1234";
+    agent.display.description = description;
+    (manager as any).listAgents = () => [agent];
+    widget.setStatsVisibility({ showTools: false, showTurns: false, showInput: false, showOutput: false, showContext: false, showTime: false });
+
+    const withTime = (widget as any).renderWidget(makeMockTUI(50), makePlainTheme())[1];
+    widget.setShowStartTime(false);
+    const withoutTime = (widget as any).renderWidget(makeMockTUI(50), makePlainTheme())[1];
+
+    expect(withTime).not.toContain(description);
+    expect(withoutTime).toContain(description);
   });
 });
 
@@ -409,24 +509,20 @@ describe("queued agent status display", () => {
     widget = new AgentWidget(manager, () => undefined);
   });
 
-  it("uses the queued display for the queue-only heading and aggregated row", () => {
-    (manager as any).listAgents = () => [makeQueuedAgent("q1"), makeQueuedAgent("q2")];
+  it("uses the queued display, local start time, and an individual row for each queued agent", () => {
+    const q1 = makeQueuedAgent("q1");
+    q1.lifecycle.startedAt = new Date(2024, 0, 2, 3, 4).getTime();
+    const q2 = makeQueuedAgent("q2");
+    q2.lifecycle.startedAt = new Date(2024, 0, 2, 3, 3).getTime();
+    (manager as any).listAgents = () => [q2, q1];
 
     const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
 
     expect(lines[0]).toMatch(/^\[dim:◇\]/);
-    expect(lines[1]).toContain("[dim:◇]");
-    expect(lines[1]).toContain("2 queued");
-  });
-
-  it("uses the queued display for individual rows during navigation", () => {
-    (manager as any).listAgents = () => [makeQueuedAgent("q1")];
-    widget.navActivate();
-
-    const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
-
-    expect(lines[1]).toContain("[dim:◇]");
+    expect(lines[1]).toContain("[dim:◇] [dim:03:04]");
     expect(lines[1]).toContain("Test agent q1");
+    expect(lines[2]).toContain("Test agent q2");
+    expect(lines.join("\n")).not.toContain("2 queued");
   });
 
   it("keeps the running-agent spinner when queued agents are also present", () => {
@@ -824,6 +920,52 @@ describe("model and thinking labels", () => {
     expect(lines[1]).toContain("(sonnet · high)");
   });
 
+  it("hides the model-and-thinking column for running, queued, and finished rows in full and compact modes", () => {
+    const running = makeRunningAgent("running");
+    running.display.invocation = { modelName: "model-running", thinkingLevel: "high" };
+    const queued = makeQueuedAgent("queued");
+    queued.display.invocation = { modelName: "model-queued", thinkingLevel: "high" };
+    const finished = makeFinishedAgent("finished");
+    finished.display.invocation = { modelName: "model-finished", thinkingLevel: "high" };
+    activity.set(running.id, makeActivity(running.id));
+    (manager as any).listAgents = () => [running, queued, finished];
+
+    for (const compact of [false, true]) {
+      widget.setWidgetShortcut(compact);
+      widget.setCompactMode(compact);
+      const shown = (widget as any).renderWidget(makeMockTUI(), makePlainTheme()).join("\n");
+      expect(shown).toContain("(model-running · high)");
+      expect(shown).toContain("(model-queued · high)");
+      expect(shown).toContain("(model-finished · high)");
+
+      widget.setShowModelThinking(false);
+      const hidden = (widget as any).renderWidget(makeMockTUI(), makePlainTheme()).join("\n");
+      expect(hidden).not.toContain("model-running");
+      expect(hidden).not.toContain("model-queued");
+      expect(hidden).not.toContain("model-finished");
+      expect(hidden).not.toContain(" · high");
+      widget.setShowModelThinking(true);
+    }
+  });
+
+  it("returns the hidden model-and-thinking column width to descriptions", () => {
+    const agent = makeRunningAgent("narrow");
+    const description = "abcdefghijklmnopqrstuvwxyz1234";
+    agent.display.description = description;
+    agent.display.invocation = { modelName: "long-model-name", thinkingLevel: "high" };
+    activity.set(agent.id, makeActivity(agent.id));
+    (manager as any).listAgents = () => [agent];
+    widget.setShowStartTime(false);
+    widget.setStatsVisibility({ showTools: false, showTurns: false, showInput: false, showOutput: false, showContext: false, showTime: false });
+
+    const withModelThinking = (widget as any).renderWidget(makeMockTUI(45), makePlainTheme())[1];
+    widget.setShowModelThinking(false);
+    const withoutModelThinking = (widget as any).renderWidget(makeMockTUI(45), makePlainTheme())[1];
+
+    expect(withModelThinking).not.toContain(description);
+    expect(withoutModelThinking).toContain(description);
+  });
+
   it("does not invent a model when none was captured", () => {
     const agent = makeRunningAgent("a1");
     agent.display.invocation = { thinkingLevel: "high" };
@@ -1012,6 +1154,14 @@ describe("max lines configuration", () => {
     expect(lines.length).toBeLessThanOrEqual(3);
   });
 
+  it("clamps full and compact widget line limits to two total lines", () => {
+    widget.setMaxLines(1);
+    widget.setMaxLinesCompact(1);
+
+    expect((widget as any).maxLines).toBe(2);
+    expect((widget as any).maxLinesCompact).toBe(2);
+  });
+
   it("shows overflow indicator when agents exceed max lines", () => {
     widget.setMaxLines(5);
     const agents = Array.from({ length: 10 }, (_, i) => makeRunningAgent(`a${i}`));
@@ -1024,19 +1174,81 @@ describe("max lines configuration", () => {
     expect(hasOverflow).toBe(true);
   });
 
-  it("prioritizes running, then queued, over finished agents when space is limited", () => {
-    widget.setMaxLines(5);
-    const running = makeRunningAgent("r1");
-    const queued = makeQueuedAgent("q1");
-    const finished = [makeFinishedAgent("f1"), makeFinishedAgent("f2")];
+  it("keeps a running header visible instead of a finished row at the two-line full-mode limit", () => {
+    widget.setMaxLines(2);
+    const running = makeRunningAgent("running");
+    const finished = makeFinishedAgent("finished");
     activity.set(running.id, makeActivity(running.id));
-    (manager as any).listAgents = () => [finished[0], queued, running, finished[1]];
+    (manager as any).listAgents = () => [finished, running];
 
     const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
 
-    expect(lines.some((line: string) => line.includes("Test agent r1"))).toBe(true);
-    expect(lines.some((line: string) => line.includes("1 queued"))).toBe(true);
-    expect(lines.some((line: string) => line.includes("Finished agent"))).toBe(false);
+    expect(lines).toHaveLength(2);
+    expect(lines.some((line: string) => line.includes("Test agent running"))).toBe(true);
+    expect(lines.some((line: string) => line.includes("Finished agent finished"))).toBe(false);
+  });
+
+  it("shows active headers before finished rows and counts only fully hidden agents", () => {
+    widget.setMaxLines(4);
+    const running = makeRunningAgent("running");
+    running.display.outputFile = "/tmp/running.log";
+    const queued = makeQueuedAgent("queued");
+    const finished = makeFinishedAgent("finished");
+    activity.set(running.id, makeActivity(running.id));
+    (manager as any).listAgents = () => [finished, running, queued];
+
+    const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
+
+    expect(lines).toHaveLength(4);
+    expect(lines.some((line: string) => line.includes("Test agent running"))).toBe(true);
+    expect(lines.some((line: string) => line.includes("Test agent queued"))).toBe(true);
+    expect(lines.some((line: string) => line.includes("Finished agent finished"))).toBe(false);
+    expect(lines.find((line: string) => line.includes("more"))).toContain("1 finished");
+    expect(lines.join("\n")).not.toContain("running, 1 queued");
+  });
+
+  it("counts finished continuation rows when applying the full-mode line budget", () => {
+    widget.setMaxLines(5);
+    const agents = Array.from({ length: 4 }, (_, index) => {
+      const agent = makeFinishedAgent(`f${index}`);
+      agent.display.outputFile = `/tmp/f${index}.log`;
+      agent.lifecycle.startedAt = new Date(2024, 0, 2, 9, index).getTime();
+      return agent;
+    });
+    (manager as any).listAgents = () => agents;
+
+    const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
+
+    expect(lines.length).toBeLessThanOrEqual(5);
+    expect(lines.filter((line: string) => line.includes("Finished agent")).length).toBe(1);
+    expect(lines.some((line: string) => line.includes("more"))).toBe(true);
+  });
+
+  it("prioritizes active agents, fills with the newest finished row, then restores global order", () => {
+    widget.setMaxLines(6);
+    const running = makeRunningAgent("r1");
+    running.lifecycle.startedAt = new Date(2024, 0, 2, 9, 0).getTime();
+    const queued = makeQueuedAgent("q1");
+    queued.lifecycle.startedAt = new Date(2024, 0, 2, 9, 3).getTime();
+    const newestFinished = makeFinishedAgent("newest");
+    newestFinished.lifecycle.startedAt = new Date(2024, 0, 2, 9, 2).getTime();
+    const olderFinished = makeFinishedAgent("older");
+    olderFinished.lifecycle.startedAt = new Date(2024, 0, 2, 9, 1).getTime();
+    const oldestFinished = makeFinishedAgent("oldest");
+    oldestFinished.lifecycle.startedAt = new Date(2024, 0, 2, 8, 59).getTime();
+    activity.set(running.id, makeActivity(running.id));
+    (manager as any).listAgents = () => [olderFinished, running, oldestFinished, queued, newestFinished];
+
+    const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
+    const queuedIndex = lines.findIndex((line: string) => line.includes("Test agent q1"));
+    const finishedIndex = lines.findIndex((line: string) => line.includes("Finished agent newest"));
+    const runningIndex = lines.findIndex((line: string) => line.includes("Test agent r1"));
+
+    expect(queuedIndex).toBeGreaterThan(0);
+    expect(finishedIndex).toBeGreaterThan(queuedIndex);
+    expect(runningIndex).toBeGreaterThan(finishedIndex);
+    expect(lines.some((line: string) => line.includes("Finished agent older"))).toBe(false);
+    expect(lines.some((line: string) => line.includes("Finished agent oldest"))).toBe(false);
     expect(lines.find((line: string) => line.includes("more"))).toContain("2 finished");
   });
 });

--- a/test/ui/agent-widget.test.ts
+++ b/test/ui/agent-widget.test.ts
@@ -466,7 +466,7 @@ describe("compact mode", () => {
     const lines = (widget as any).renderWidget(makeMockTUI(90), makePlainTheme());
     const runningLine = lines.find((line: string) => line.includes("Run task"))!;
 
-    expect(runningLine).toContain("5🛠");
+    expect(runningLine).toContain("5⚙︎");
     expect(runningLine).toContain("reading");
   });
 });
@@ -493,7 +493,7 @@ describe("full mode narrow layout", () => {
     const lines = (widget as any).renderWidget(makeMockTUI(70), makePlainTheme());
     const runningLine = lines.find((line: string) => line.includes("Run task"))!;
 
-    expect(runningLine).toContain("5🛠");
+    expect(runningLine).toContain("5⚙︎");
     expect(runningLine).toContain("↑1.0k");
   });
 });
@@ -520,7 +520,7 @@ describe("narrow model and thinking labels", () => {
     (manager as any).listAgents = () => [agent];
 
     const fullLine = (widget as any).renderWidget(makeMockTUI(70), makePlainTheme())[1];
-    expect(fullLine).toContain("5🛠");
+    expect(fullLine).toContain("5⚙︎");
     expect(fullLine).toContain("↑1.0k");
     expect(fullLine).not.toContain("undefined");
     expect(visibleWidth(fullLine)).toBeLessThanOrEqual(70);
@@ -528,7 +528,7 @@ describe("narrow model and thinking labels", () => {
     widget.setCompactMode(true);
     widget.setWidgetShortcut(true);
     const compactLine = (widget as any).renderWidget(makeMockTUI(70), makePlainTheme())[1];
-    expect(compactLine).toContain("5🛠");
+    expect(compactLine).toContain("5⚙︎");
     expect(compactLine).toContain("↑1.0k");
     expect(compactLine).toContain("reading");
     expect(compactLine).not.toContain("undefined");
@@ -684,7 +684,7 @@ describe("model and thinking labels", () => {
     const runningHeader = assertColumnGaps(findHeader(fullLines, "Running description"), "Builder", "(very-long-model · thinking: high)", "Running description");
     assertColumnGaps(findHeader(fullLines, "Queued description"), "Queue", "(sonnet)", "Queued description");
     expect(finishedHeader.indexOf("Finished description")).toBe(runningHeader.indexOf("Running description"));
-    expect(finishedHeader.indexOf("10🛠")).toBe(runningHeader.indexOf("5🛠"));
+    expect(finishedHeader.indexOf("10⚙︎")).toBe(runningHeader.indexOf("5⚙︎"));
 
     widget.setCompactMode(true);
     widget.setWidgetShortcut(true);
@@ -716,7 +716,7 @@ describe("model and thinking labels", () => {
     const columnStart = (line: string, text: string) => visibleWidth(line.slice(0, line.indexOf(text)));
 
     expect(columnStart(cjkHeader, "解析")).toBe(columnStart(asciiHeader, "abcdef"));
-    expect(columnStart(cjkHeader, "1🛠")).toBe(columnStart(asciiHeader, "2🛠"));
+    expect(columnStart(cjkHeader, "1⚙︎")).toBe(columnStart(asciiHeader, "2⚙︎"));
   });
 });
 
@@ -1062,7 +1062,7 @@ describe("stats visibility integration", () => {
 
     const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
     const allText = lines.join(" ");
-    expect(allText).not.toContain("🛠");
+    expect(allText).not.toContain("⚙︎");
   });
 
   it("hides time when showTime is false", () => {
@@ -1115,7 +1115,7 @@ describe("stats visibility integration", () => {
 
     const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
     const allText = lines.join(" ");
-    expect(allText).not.toContain("🛠");
+    expect(allText).not.toContain("⚙︎");
   });
 
   it("shows all stats when visibility flags are all true (default)", () => {
@@ -1133,7 +1133,7 @@ describe("stats visibility integration", () => {
 
     const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
     const allText = lines.join(" ");
-    expect(allText).toContain("🛠");
+    expect(allText).toContain("⚙︎");
     expect(allText).toContain("⟳");
     expect(allText).toContain("↑");
     expect(allText).toContain("$");

--- a/test/ui/agent-widget.test.ts
+++ b/test/ui/agent-widget.test.ts
@@ -273,7 +273,7 @@ describe("widget rendering format", () => {
       expect(line).not.toContain("[dim:");
     });
 
-    it("separates every running and finished stats group with two spaces", () => {
+    it("uses semantic stats groups while keeping tool and turn cells contiguous", () => {
       const running = makeRunningAgent("running");
       const finished = makeFinishedAgent("finished");
       for (const agent of [running, finished]) {
@@ -289,10 +289,10 @@ describe("widget rendering format", () => {
 
       expect(statsRows).toHaveLength(2);
       for (const row of statsRows) {
-        expect(row).toContain("20⚙︎  6⟳  ↑1.0k ↓500");
-        expect(row).toMatch(/↑1\.0k ↓500  (?:\d+m(?: \d+s)?|\d+s)/);
-        expect(row).not.toContain("20⚙︎ ·");
-        expect(row).not.toContain("6⟳ ·");
+        expect(row).toContain("20⚙︎  6⟳ · ↑1.0k ↓500 ·");
+        expect(row).toMatch(/↑1\.0k ↓500 · (?:\d+m(?: \d+s)?|\d+s)/);
+        expect(row).not.toContain("20⚙︎ · 6⟳");
+        expect(row).not.toContain("20⚙︎  6⟳  ↑");
       }
     });
 
@@ -311,7 +311,7 @@ describe("widget rendering format", () => {
       const statsLine = (widget as any).buildStatsLine(agent, ansiTheme);
 
       expect(statsLine).toContain("\u001b[31m90.1%/272k\u001b[39m");
-      expect(statsLine).toContain("\u001b[31m90.1%/272k\u001b[39m\u001b[97m  ");
+      expect(statsLine).toContain("\u001b[31m90.1%/272k\u001b[39m\u001b[97m · ");
     });
   });
 
@@ -349,6 +349,27 @@ describe("widget rendering format", () => {
       expect(lines[4]).toMatch(/^\[dim:\s{4}/);
       expect(lines[2]).toContain("out1.log");
       expect(lines[4]).toContain("out2.log");
+    });
+
+    it("dims raw finished stats without applying the running text foreground", () => {
+      const agent = makeFinishedAgent("a1");
+      agent.stats.contextPercent = 95;
+      agent.stats.contextWindow = 272000;
+      (manager as any).listAgents = () => [agent];
+      const ansiTheme = {
+        fg: (color: string, text: string) => {
+          const code = color === "dim" ? 2 : color === "error" ? 31 : color === "text" ? 97 : 37;
+          const reset = color === "dim" ? 22 : 39;
+          return `\u001b[${code}m${text}\u001b[${reset}m`;
+        },
+        bold: (text: string) => text,
+      };
+
+      const line = (widget as any).renderWidget(makeMockTUI(), ansiTheme)[1];
+
+      expect(line).toContain("\u001b[2m10⚙︎");
+      expect(line).toContain("\u001b[31m95.0%/272k\u001b[39m");
+      expect(line).not.toContain("\u001b[97m");
     });
   });
 
@@ -859,8 +880,8 @@ describe("model and thinking labels", () => {
       const plain = stripMockStyling(line);
       const nameStart = plain.indexOf(name);
       const labelStart = plain.indexOf(label);
-      expect(labelStart).toBe(nameStart + nameWidth + 3);
-      expect(plain.indexOf(description)).toBe(labelStart + labelWidth + 4);
+      expect(labelStart).toBe(nameStart + nameWidth + 2);
+      expect(plain.indexOf(description)).toBe(labelStart + labelWidth + 2);
       return plain;
     };
     const findHeader = (lines: string[], description: string) =>
@@ -871,7 +892,8 @@ describe("model and thinking labels", () => {
     const runningHeader = assertColumnGaps(findHeader(fullLines, "Running description"), "Builder", "(very-long-model · high)", "Running description");
     assertColumnGaps(findHeader(fullLines, "Queued description"), "Queue", "(sonnet)", "Queued description");
     expect(finishedHeader.indexOf("Finished description")).toBe(runningHeader.indexOf("Running description"));
-    expect(finishedHeader.indexOf("10⚙︎")).toBe(runningHeader.indexOf("5⚙︎"));
+    const statEnd = (line: string, stat: string) => visibleWidth(line.slice(0, line.indexOf(stat))) + visibleWidth(stat);
+    expect(statEnd(finishedHeader, "10⚙︎")).toBe(statEnd(runningHeader, "5⚙︎"));
 
     widget.setCompactMode(true);
     widget.setWidgetShortcut(true);
@@ -883,7 +905,7 @@ describe("model and thinking labels", () => {
     queued.display.invocation = undefined;
     const noModelLines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
     const noModelRunningHeader = stripMockStyling(findHeader(noModelLines, "Running description"));
-    expect(noModelRunningHeader).toContain("Builder   Running description");
+    expect(noModelRunningHeader).toContain("Builder  Running description");
   });
 
   it("aligns columns by terminal width for CJK names, models, and descriptions", () => {
@@ -904,6 +926,52 @@ describe("model and thinking labels", () => {
 
     expect(columnStart(cjkHeader, "解析")).toBe(columnStart(asciiHeader, "abcdef"));
     expect(columnStart(cjkHeader, "1⚙︎")).toBe(columnStart(asciiHeader, "2⚙︎"));
+  });
+
+  it("aligns structured stats across heterogeneous running and finished rows", () => {
+    const running = makeRunningAgent("running");
+    running.lifecycle.startedAt = Date.now() - 147_000;
+    running.stats = {
+      ...running.stats,
+      toolUses: 22,
+      turnCount: 13,
+      lifetimeUsage: { input: 98_000, output: 6_000, cacheWrite: 3_000, cost: 0.024 },
+      cacheRead: 459_000,
+      latestCacheHitRate: 94.3,
+      contextPercent: 45,
+      contextWindow: 128_000,
+      autoCompactionEnabled: true,
+    };
+    const finished = makeFinishedAgent("finished");
+    finished.lifecycle.startedAt = Date.now() - 149_000;
+    finished.lifecycle.completedAt = Date.now() - 60_000;
+    finished.stats = {
+      ...finished.stats,
+      toolUses: 9,
+      turnCount: 2,
+      lifetimeUsage: { input: 78_000, output: 3_000, cacheWrite: 0, cost: 1.2 },
+      cacheRead: 85_000,
+      latestCacheHitRate: 92.1,
+      contextPercent: 9,
+      contextWindow: 128_000,
+    };
+    activity.set(running.id, makeActivity(running.id));
+    (manager as any).listAgents = () => [running, finished];
+
+    const lines = (widget as any).renderWidget(makeMockTUI(), makePlainTheme());
+    const runningHeader = lines.find((line: string) => line.includes("22⚙︎"))!;
+    const finishedHeader = lines.find((line: string) => line.includes("9⚙︎"))!;
+    const start = (line: string, text: string) => visibleWidth(line.slice(0, line.indexOf(text)));
+    const end = (line: string, text: string) => start(line, text) + visibleWidth(text);
+
+    expect(runningHeader).toContain("22⚙︎  13⟳ ·");
+    expect(finishedHeader).toMatch(/\s9⚙︎\s{2}\s2⟳ ·/);
+    expect(runningHeader).not.toContain("22⚙︎ ·");
+    expect(end(runningHeader, "22⚙︎")).toBe(end(finishedHeader, "9⚙︎"));
+    expect(end(runningHeader, "13⟳")).toBe(end(finishedHeader, "2⟳"));
+    for (const [left, right] of [["↑98k", "↑78k"], ["↓6.0k", "↓3.0k"], ["R459k", "R85k"], ["CH94.3%", "CH92.1%"], ["$0.024", "$1.200"], ["45.0%/128k", "9.0%/128k"], ["2m 27s", "1m 29s"]]) {
+      expect(start(runningHeader, left)).toBe(start(finishedHeader, right));
+    }
   });
 });
 

--- a/test/ui/agent-widget.test.ts
+++ b/test/ui/agent-widget.test.ts
@@ -92,6 +92,12 @@ function makeRunningAgent(id: string, type: string = "builder"): any {
   };
 }
 
+function makeQueuedAgent(id: string, type: string = "builder"): any {
+  const agent = makeRunningAgent(id, type);
+  agent.lifecycle.status = "queued";
+  return agent;
+}
+
 function makeFinishedAgent(id: string, type: string = "builder"): any {
   return {
     id,
@@ -278,6 +284,59 @@ describe("widget rendering format", () => {
   });
 });
 
+describe("queued agent status display", () => {
+  let widget: AgentWidget;
+  let manager: AgentManager;
+
+  beforeEach(() => {
+    manager = makeMockManager([]);
+    widget = new AgentWidget(manager, () => undefined);
+  });
+
+  it("uses the queued display for the queue-only heading and aggregated row", () => {
+    (manager as any).listAgents = () => [makeQueuedAgent("q1"), makeQueuedAgent("q2")];
+
+    const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
+
+    expect(lines[0]).toMatch(/^\[dim:◇\]/);
+    expect(lines[1]).toContain("[dim:◇]");
+    expect(lines[1]).toContain("2 queued");
+  });
+
+  it("uses the queued display for individual rows during navigation", () => {
+    (manager as any).listAgents = () => [makeQueuedAgent("q1")];
+    widget.navActivate();
+
+    const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
+
+    expect(lines[1]).toContain("[dim:◇]");
+    expect(lines[1]).toContain("Test agent q1");
+  });
+
+  it("keeps the running-agent spinner when queued agents are also present", () => {
+    const running = makeRunningAgent("running");
+    (manager as any).listAgents = () => [running, makeQueuedAgent("queued")];
+
+    const lines = (widget as any).renderWidget(makeMockTUI(), makePlainTheme());
+
+    expect(lines[0]).toMatch(/^◈ Agents/);
+    expect(lines.find((line: string) => line.includes("Test agent running"))).toContain("⠋");
+  });
+});
+
+describe("finished agent status icons", () => {
+  it.each([
+    ["completed", "✓"],
+    ["turn_limited", "✓"],
+    ["stopped", "■"],
+    ["error", "✗"],
+    ["aborted", "✗"],
+  ])("uses %s icon %s", (status, icon) => {
+    const widget = new AgentWidget(makeMockManager([]), () => undefined);
+    expect((widget as any).finishedIconAndStatus(status, undefined, makePlainTheme()).icon).toBe(icon);
+  });
+});
+
 describe("status bar format", () => {
   it("shows 'N agents: $cost' format with running agents", () => {
     const uiCtx = { setStatus: vi.fn(), setWidget: vi.fn() };
@@ -297,7 +356,7 @@ describe("status bar format", () => {
     expect(uiCtx.setStatus).toHaveBeenCalledWith("subagents", expect.stringMatching(/^2 agents: \$0\.\d+$/));
   });
 
-  it("shows 'agents: $cost' format when no running/queued agents but finished exist", () => {
+  it("shows finished-agent count and cost when no running/queued agents exist", () => {
     const uiCtx = { setStatus: vi.fn(), setWidget: vi.fn() };
     const activity = new Map();
     const manager = makeMockManager([], 0.01);
@@ -310,7 +369,19 @@ describe("status bar format", () => {
     (manager as any).listAgents = () => [finished];
     widget.update();
 
-    expect(uiCtx.setStatus).toHaveBeenCalledWith("subagents", expect.stringMatching(/^agents: \$0\.\d+$/));
+    expect(uiCtx.setStatus).toHaveBeenCalledWith("subagents", expect.stringMatching(/^1 finished agent: \$0\.\d+$/));
+  });
+
+  it("reports finished agents separately from active agents", () => {
+    const uiCtx = { setStatus: vi.fn(), setWidget: vi.fn() };
+    const manager = makeMockManager([]);
+    const widget = new AgentWidget(manager, () => undefined);
+    widget.setUICtx(uiCtx);
+
+    (manager as any).listAgents = () => [makeRunningAgent("running"), makeFinishedAgent("finished-1"), makeFinishedAgent("finished-2")];
+    widget.update();
+
+    expect(uiCtx.setStatus).toHaveBeenCalledWith("subagents", "1 agent · 2 finished agents");
   });
 
   it("shows 'N agents' without cost when cost is zero", () => {

--- a/test/ui/agent-widget.test.ts
+++ b/test/ui/agent-widget.test.ts
@@ -10,6 +10,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { AgentManager } from "../../src/agents/agent-manager.js";
 import type { LiveView } from "../../src/spawn/spawn-coordinator.js";
+import { visibleWidth } from "@earendil-works/pi-tui";
 import { AgentWidget, formatMs } from "../../src/ui/agent-widget.js";
 
 /* ------------------------------------------------------------------ */
@@ -25,9 +26,13 @@ vi.mock("../../src/agents/agent-types.js", () => ({
   }),
 }));
 
-vi.mock("@earendil-works/pi-tui", () => ({
-  truncateToWidth: (text: string, width: number) => text,
-}));
+vi.mock("@earendil-works/pi-tui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@earendil-works/pi-tui")>();
+  return {
+    truncateToWidth: actual.truncateToWidth,
+    visibleWidth: actual.visibleWidth,
+  };
+});
 
 function makeMockManager(agents: any[], totalAgentCost = 0): AgentManager {
   return {
@@ -54,8 +59,15 @@ function makeMockTheme(): any {
   };
 }
 
-function makeMockTUI(): any {
-  return { terminal: { columns: 200 } };
+function makePlainTheme(): any {
+  return {
+    fg: (_color: string, text: string) => text,
+    bold: (text: string) => text,
+  };
+}
+
+function makeMockTUI(columns = 200): any {
+  return { terminal: { columns } };
 }
 
 function makeRunningAgent(id: string, type: string = "builder"): any {
@@ -438,6 +450,273 @@ describe("compact mode", () => {
     const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
     // Heading + 1 header + 1 activity continuation
     expect(lines.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("keeps running stats and activity visible beside a long finished description",  () => {
+    widget.setCompactMode(true);
+    widget.setWidgetShortcut(true);
+    widget.setDescLengthCompact(12);
+    const finished = makeFinishedAgent("finished");
+    finished.display.description = "A finished description that is much too long for the compact row";
+    const running = makeRunningAgent("running");
+    running.display.description = "Run task";
+    activity.set(running.id, makeActivity(running.id));
+    (manager as any).listAgents = () => [finished, running];
+
+    const lines = (widget as any).renderWidget(makeMockTUI(90), makePlainTheme());
+    const runningLine = lines.find((line: string) => line.includes("Run task"))!;
+
+    expect(runningLine).toContain("5🛠");
+    expect(runningLine).toContain("reading");
+  });
+});
+
+describe("full mode narrow layout", () => {
+  let widget: AgentWidget;
+  let manager: AgentManager;
+  let activity: Map<string, LiveView>;
+
+  beforeEach(() => {
+    manager = makeMockManager([]);
+    activity = new Map();
+    widget = new AgentWidget(manager, (id) => activity.get(id));
+  });
+
+  it("keeps a short running agent's usage visible beside a long finished description", () => {
+    const finished = makeFinishedAgent("finished");
+    finished.display.description = "A finished description that consumes the entire shared description column";
+    const running = makeRunningAgent("running");
+    running.display.description = "Run task";
+    activity.set(running.id, makeActivity(running.id));
+    (manager as any).listAgents = () => [finished, running];
+
+    const lines = (widget as any).renderWidget(makeMockTUI(70), makePlainTheme());
+    const runningLine = lines.find((line: string) => line.includes("Run task"))!;
+
+    expect(runningLine).toContain("5🛠");
+    expect(runningLine).toContain("↑1.0k");
+  });
+});
+
+describe("narrow model and thinking labels", () => {
+  let widget: AgentWidget;
+  let manager: AgentManager;
+  let activity: Map<string, LiveView>;
+
+  beforeEach(() => {
+    manager = makeMockManager([]);
+    activity = new Map();
+    widget = new AgentWidget(manager, (id) => activity.get(id));
+  });
+
+  it("keeps running stats visible at 70 columns with a long model and thinking label", () => {
+    const agent = makeRunningAgent("a1");
+    agent.display.description = "A description that may use only the remaining space";
+    agent.display.invocation = {
+      modelName: "a-very-long-model-name-that-must-be-truncated",
+      thinkingLevel: "high",
+    };
+    activity.set(agent.id, makeActivity(agent.id));
+    (manager as any).listAgents = () => [agent];
+
+    const fullLine = (widget as any).renderWidget(makeMockTUI(70), makePlainTheme())[1];
+    expect(fullLine).toContain("5🛠");
+    expect(fullLine).toContain("↑1.0k");
+    expect(fullLine).not.toContain("undefined");
+    expect(visibleWidth(fullLine)).toBeLessThanOrEqual(70);
+
+    widget.setCompactMode(true);
+    widget.setWidgetShortcut(true);
+    const compactLine = (widget as any).renderWidget(makeMockTUI(70), makePlainTheme())[1];
+    expect(compactLine).toContain("5🛠");
+    expect(compactLine).toContain("↑1.0k");
+    expect(compactLine).toContain("reading");
+    expect(compactLine).not.toContain("undefined");
+    expect(visibleWidth(compactLine)).toBeLessThanOrEqual(70);
+  });
+});
+
+describe("Pi usage display", () => {
+  let widget: AgentWidget;
+  let manager: AgentManager;
+  let activity: Map<string, LiveView>;
+
+  beforeEach(() => {
+    manager = makeMockManager([]);
+    activity = new Map();
+    widget = new AgentWidget(manager, (id) => activity.get(id));
+  });
+
+  it("uses the same complete Pi block for live and completed records", () => {
+    const usage = {
+      input: 83000, output: 7100, cacheWrite: 12000, cost: 1.262,
+    };
+    const live = makeRunningAgent("live");
+    live.stats = {
+      ...live.stats, lifetimeUsage: usage, cacheRead: 1300000, latestCacheHitRate: 99.1,
+    };
+    live.execution.session = {
+      getContextUsage: () => ({ percent: 23.4, contextWindow: 272000 }),
+      autoCompactionEnabled: true,
+      model: { provider: "kimi-coding" },
+    };
+    const finished = makeFinishedAgent("finished");
+    finished.stats = {
+      ...finished.stats, lifetimeUsage: usage, cacheRead: 1300000, latestCacheHitRate: 99.1,
+      contextPercent: 23.4, contextWindow: 272000, autoCompactionEnabled: true, usingSubscription: true,
+    };
+    (manager as any).listAgents = () => [live, finished];
+
+    widget.setShowCost(true);
+    const lines = (widget as any).renderWidget(makeMockTUI(), makePlainTheme()).join("\n");
+    const expected = "↑83k ↓7.1k R1.3M W12k CH99.1% $1.262 (sub) 23.4%/272k (auto)";
+    expect(lines.split(expected)).toHaveLength(3);
+  });
+});
+
+describe("model and thinking labels", () => {
+  let widget: AgentWidget;
+  let manager: AgentManager;
+  let activity: Map<string, LiveView>;
+
+  beforeEach(() => {
+    manager = makeMockManager([]);
+    activity = new Map();
+    widget = new AgentWidget(manager, (id) => activity.get(id));
+  });
+
+  it("shows model and concrete thinking level for a running agent in full mode", () => {
+    const agent = makeRunningAgent("a1");
+    agent.display.invocation = { modelName: "sonnet", thinkingLevel: "high" };
+    activity.set("a1", makeActivity("a1"));
+    (manager as any).listAgents = () => [agent];
+
+    const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
+    expect(lines[1]).toContain("(sonnet · thinking: high)");
+  });
+
+  it("shows model and concrete thinking level for a running agent in compact mode", () => {
+    widget.setCompactMode(true);
+    widget.setWidgetShortcut(true);
+    const agent = makeRunningAgent("a1");
+    agent.display.invocation = { modelName: "sonnet", thinkingLevel: "high" };
+    activity.set("a1", makeActivity("a1"));
+    (manager as any).listAgents = () => [agent];
+
+    const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toContain("(sonnet · thinking: high)");
+  });
+
+  it("shows model and concrete thinking level for a finished agent", () => {
+    const agent = makeFinishedAgent("a1");
+    agent.display.invocation = { modelName: "sonnet", thinkingLevel: "high" };
+    (manager as any).listAgents = () => [agent];
+
+    const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
+    expect(lines[1]).toContain("(sonnet · thinking: high)");
+  });
+
+  it("does not invent a model when none was captured", () => {
+    const agent = makeRunningAgent("a1");
+    agent.display.invocation = { thinkingLevel: "high" };
+    activity.set("a1", makeActivity("a1"));
+    (manager as any).listAgents = () => [agent];
+
+    const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
+    expect(lines[1]).toContain("(thinking: high)");
+    expect(lines[1]).not.toContain("undefined");
+  });
+
+  it("shows a model without a missing, inherited, or invalid thinking level", () => {
+    const agents = ["missing", "inherit", "invalid"].map((id) => {
+      const agent = makeRunningAgent(id);
+      agent.display.invocation = {
+        modelName: "sonnet",
+        thinkingLevel: id === "missing" ? undefined : id === "inherit" ? "inherit" : "invalid",
+      };
+      activity.set(id, makeActivity(id));
+      return agent;
+    });
+    (manager as any).listAgents = () => agents;
+
+    const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
+    for (const line of [lines[1], lines[3], lines[5]]) {
+      expect(line).toContain("(sonnet)");
+      expect(line).not.toContain("thinking:");
+    }
+  });
+
+  it("uses fixed column gaps for full, compact, finished, and individual queued rows", () => {
+    const finished = makeFinishedAgent("finished", "explore");
+    finished.display.description = "Finished description";
+    finished.display.invocation = { modelName: "haiku" };
+    const running = makeRunningAgent("running", "builder");
+    running.display.description = "Running description";
+    running.display.invocation = { modelName: "very-long-model", thinkingLevel: "high" };
+    const queued = makeRunningAgent("queued", "queue");
+    queued.lifecycle.status = "queued";
+    queued.display.description = "Queued description";
+    queued.display.invocation = { modelName: "sonnet" };
+    activity.set(running.id, makeActivity(running.id));
+    (manager as any).listAgents = () => [finished, running, queued];
+    widget.navActivate();
+
+    const stripMockStyling = (line: string) => line
+      .replace(/\[(?:accent|dim|success|error|warning|muted):/g, "")
+      .replaceAll("]", "")
+      .replaceAll("**", "");
+    const labelWidth = "(very-long-model · thinking: high)".length;
+    const nameWidth = "Explore".length;
+    const assertColumnGaps = (line: string, name: string, label: string, description: string) => {
+      const plain = stripMockStyling(line);
+      const nameStart = plain.indexOf(name);
+      const labelStart = plain.indexOf(label);
+      expect(labelStart).toBe(nameStart + nameWidth + 3);
+      expect(plain.indexOf(description)).toBe(labelStart + labelWidth + 4);
+      return plain;
+    };
+    const findHeader = (lines: string[], description: string) =>
+      lines.find((line) => line.includes(description))!;
+
+    const fullLines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
+    const finishedHeader = assertColumnGaps(findHeader(fullLines, "Finished description"), "Explore", "(haiku)", "Finished description");
+    const runningHeader = assertColumnGaps(findHeader(fullLines, "Running description"), "Builder", "(very-long-model · thinking: high)", "Running description");
+    assertColumnGaps(findHeader(fullLines, "Queued description"), "Queue", "(sonnet)", "Queued description");
+    expect(finishedHeader.indexOf("Finished description")).toBe(runningHeader.indexOf("Running description"));
+    expect(finishedHeader.indexOf("10🛠")).toBe(runningHeader.indexOf("5🛠"));
+
+    widget.setCompactMode(true);
+    widget.setWidgetShortcut(true);
+    const compactLines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
+    assertColumnGaps(findHeader(compactLines, "Running description"), "Builder", "(very-long-model · thinking: high)", "Running description");
+
+    finished.display.invocation = undefined;
+    running.display.invocation = undefined;
+    queued.display.invocation = undefined;
+    const noModelLines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
+    const noModelRunningHeader = stripMockStyling(findHeader(noModelLines, "Running description"));
+    expect(noModelRunningHeader).toContain("Builder   Running description");
+  });
+
+  it("aligns columns by terminal width for CJK names, models, and descriptions", () => {
+    const cjk = makeRunningAgent("cjk", "研究");
+    cjk.display.description = "解析";
+    cjk.display.invocation = { modelName: "模型" };
+    cjk.stats.toolUses = 1;
+    const ascii = makeRunningAgent("ascii", "builder");
+    ascii.display.description = "abcdef";
+    ascii.display.invocation = { modelName: "sonnet" };
+    ascii.stats.toolUses = 2;
+    (manager as any).listAgents = () => [cjk, ascii];
+
+    const lines = (widget as any).renderWidget(makeMockTUI(), makePlainTheme());
+    const cjkHeader = lines.find((line: string) => line.includes("解析"))!;
+    const asciiHeader = lines.find((line: string) => line.includes("abcdef"))!;
+    const columnStart = (line: string, text: string) => visibleWidth(line.slice(0, line.indexOf(text)));
+
+    expect(columnStart(cjkHeader, "解析")).toBe(columnStart(asciiHeader, "abcdef"));
+    expect(columnStart(cjkHeader, "1🛠")).toBe(columnStart(asciiHeader, "2🛠"));
   });
 });
 

--- a/test/ui/agent-widget.test.ts
+++ b/test/ui/agent-widget.test.ts
@@ -329,17 +329,29 @@ describe("widget rendering format", () => {
     });
   });
 
-  describe("mixed running and finished", () => {
-    it("uses 2-space prefix for all items regardless of type", () => {
-      const running = makeRunningAgent("r1");
+  describe("mixed agent statuses", () => {
+    it("renders running, queued, then finished while preserving each group's order", () => {
+      const newerRunning = makeRunningAgent("r-new");
+      newerRunning.display.description = "Newer running";
+      const olderRunning = makeRunningAgent("r-old");
+      olderRunning.display.description = "Older running";
+      const queued = makeQueuedAgent("q1");
       const finished = makeFinishedAgent("f1");
-      activity.set("r1", makeActivity("r1"));
-      (manager as any).listAgents = () => [finished, running];
+      activity.set(newerRunning.id, makeActivity(newerRunning.id));
+      activity.set(olderRunning.id, makeActivity(olderRunning.id));
+      // The manager provides each status group newest-first, interleaved by status.
+      (manager as any).listAgents = () => [finished, newerRunning, queued, olderRunning];
 
       const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
-      // Both use 2-space prefix
-      expect(lines[1]).toMatch(/^  /); // finished agent
-      expect(lines[2]).toMatch(/^  /); // running agent
+      const runningNewIndex = lines.findIndex((line: string) => line.includes("Newer running"));
+      const runningOldIndex = lines.findIndex((line: string) => line.includes("Older running"));
+      const queuedIndex = lines.findIndex((line: string) => line.includes("1 queued"));
+      const finishedIndex = lines.findIndex((line: string) => line.includes("Finished agent f1"));
+
+      expect(runningNewIndex).toBeGreaterThan(0);
+      expect(runningOldIndex).toBeGreaterThan(runningNewIndex);
+      expect(queuedIndex).toBeGreaterThan(runningOldIndex);
+      expect(finishedIndex).toBeGreaterThan(queuedIndex);
     });
   });
 });
@@ -919,6 +931,22 @@ describe("max lines configuration", () => {
     // Should have overflow indicator
     const hasOverflow = lines.some((l: string) => l.includes("more"));
     expect(hasOverflow).toBe(true);
+  });
+
+  it("prioritizes running, then queued, over finished agents when space is limited", () => {
+    widget.setMaxLines(5);
+    const running = makeRunningAgent("r1");
+    const queued = makeQueuedAgent("q1");
+    const finished = [makeFinishedAgent("f1"), makeFinishedAgent("f2")];
+    activity.set(running.id, makeActivity(running.id));
+    (manager as any).listAgents = () => [finished[0], queued, running, finished[1]];
+
+    const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
+
+    expect(lines.some((line: string) => line.includes("Test agent r1"))).toBe(true);
+    expect(lines.some((line: string) => line.includes("1 queued"))).toBe(true);
+    expect(lines.some((line: string) => line.includes("Finished agent"))).toBe(false);
+    expect(lines.find((line: string) => line.includes("more"))).toContain("2 finished");
   });
 });
 

--- a/test/ui/agent-widget.test.ts
+++ b/test/ui/agent-widget.test.ts
@@ -52,6 +52,7 @@ function makeMockTheme(): any {
     error: "error",
     warning: "warning",
     muted: "muted",
+    text: "text",
   };
   return {
     fg: (color: string, text: string) => `[${color}:${text}]`,
@@ -161,7 +162,7 @@ describe("widget rendering format", () => {
 
       const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
       // Activity line is the second line (index 2, after heading)
-      expect(lines[2]).toMatch(/^\[dim:  [│└]/);
+      expect(lines[2]).toMatch(/^\[text:  [│└]/);
     });
 
     it("places outputFile line before activity line", () => {
@@ -173,7 +174,7 @@ describe("widget rendering format", () => {
       const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
       // line[1] = header, line[2] = outputFile, line[3] = activity
       expect(lines[2]).toContain("tail -f");
-      expect(lines[3]).toMatch(/^\[dim:  [│└]/);
+      expect(lines[3]).toMatch(/^\[text:  [│└]/);
       expect(lines[3]).toContain("reading");
     });
 
@@ -183,7 +184,7 @@ describe("widget rendering format", () => {
       (manager as any).listAgents = () => [agent];
 
       const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
-      expect(lines[2]).toMatch(/^\[dim:  └/);
+      expect(lines[2]).toMatch(/^\[text:  └/);
     });
   });
 
@@ -210,8 +211,8 @@ describe("widget rendering format", () => {
 
       const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
       // Activity lines use │ or └ connector
-      expect(lines[2]).toMatch(/^\[dim:  [│└]/);
-      expect(lines[4]).toMatch(/^\[dim:  [│└]/);
+      expect(lines[2]).toMatch(/^\[text:  [│└]/);
+      expect(lines[4]).toMatch(/^\[text:  [│└]/);
     });
 
     it("places outputFile before activity for each running agent", () => {
@@ -229,6 +230,65 @@ describe("widget rendering format", () => {
       expect(lines[3]).toContain("reading");
       expect(lines[5]).toContain("out2.log");
       expect(lines[6]).toContain("reading");
+    });
+  });
+
+  describe("running agent text colors", () => {
+    it("uses text for every regular full-row part while keeping the spinner accented", () => {
+      const agent = makeRunningAgent("a1");
+      agent.display.invocation = { modelName: "sonnet", thinkingLevel: "high" };
+      agent.display.worktreeLabel = "feature";
+      agent.display.outputFile = "/tmp/output.log";
+      activity.set(agent.id, makeActivity(agent.id));
+      (manager as any).listAgents = () => [agent];
+
+      const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
+
+      expect(lines[1]).toContain("[accent:⠋]");
+      expect(lines[1]).toContain("[text:**Builder**]");
+      expect(lines[1]).toContain("[text:(sonnet · high)]");
+      expect(lines[1]).toContain("[text:Test agent a1]");
+      expect(lines[1]).toContain("[text:5⚙︎");
+      expect(lines[2]).toMatch(/^\[text:  │ @feature  tail -f \/tmp\/output\.log\]/);
+      expect(lines[3]).toMatch(/^\[text:  └ reading…\]/);
+      expect(lines.slice(1).join("\n")).not.toContain("[dim:");
+    });
+
+    it("uses text for every regular compact-row part", () => {
+      widget.setCompactMode(true);
+      widget.setWidgetShortcut(true);
+      const agent = makeRunningAgent("a1");
+      agent.display.invocation = { modelName: "sonnet", thinkingLevel: "high" };
+      activity.set(agent.id, makeActivity(agent.id));
+      (manager as any).listAgents = () => [agent];
+
+      const line = (widget as any).renderWidget(makeMockTUI(), makeMockTheme())[1];
+
+      expect(line).toContain("[accent:⠋]");
+      expect(line).toContain("[text:**Builder**]");
+      expect(line).toContain("[text:(sonnet · high)]");
+      expect(line).toContain("[text:Test agent a1]");
+      expect(line).toContain("[text:5⚙︎");
+      expect(line).toContain("[text:reading…]");
+      expect(line).not.toContain("[dim:");
+    });
+
+    it("preserves an error stat color and reapplies text after its ANSI foreground reset", () => {
+      const agent = makeRunningAgent("a1");
+      agent.stats.contextPercent = 90.1;
+      agent.stats.contextWindow = 272000;
+      const ansiTheme = {
+        fg: (color: string, text: string) => {
+          const code = color === "error" ? 31 : color === "text" ? 97 : 37;
+          return `\u001b[${code}m${text}\u001b[39m`;
+        },
+        bold: (text: string) => text,
+      };
+
+      const statsLine = (widget as any).buildStatsLine(agent, ansiTheme);
+
+      expect(statsLine).toContain("\u001b[31m90.1%/272k\u001b[39m");
+      expect(statsLine).toContain("\u001b[31m90.1%/272k\u001b[39m\u001b[97m · ");
     });
   });
 
@@ -338,6 +398,26 @@ describe("finished agent status icons", () => {
 });
 
 describe("status bar format", () => {
+  it("uses Pi's dim token and restyles status text after widget invalidation", () => {
+    const uiCtx = { theme: makeMockTheme(), setStatus: vi.fn(), setWidget: vi.fn() };
+    const widget = new AgentWidget(makeMockManager([]), () => undefined);
+    widget.setUICtx(uiCtx);
+    (widget as any).manager.listAgents = () => [makeRunningAgent("a1")];
+
+    widget.update();
+
+    expect(uiCtx.setStatus).toHaveBeenCalledWith("subagents", "[dim:1 agent]");
+
+    uiCtx.theme = {
+      fg: (color: string, text: string) => `[new-${color}:${text}]`,
+      bold: (text: string) => text,
+    };
+    const widgetFactory = (uiCtx.setWidget as any).mock.calls[0][1];
+    widgetFactory(makeMockTUI(), makeMockTheme()).invalidate();
+
+    expect(uiCtx.setStatus).toHaveBeenLastCalledWith("subagents", "[new-dim:1 agent]");
+  });
+
   it("shows 'N agents: $cost' format with running agents", () => {
     const uiCtx = { setStatus: vi.fn(), setWidget: vi.fn() };
     const activity = new Map();
@@ -663,7 +743,7 @@ describe("model and thinking labels", () => {
     (manager as any).listAgents = () => [agent];
 
     const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
-    expect(lines[1]).toContain("(sonnet · thinking: high)");
+    expect(lines[1]).toContain("(sonnet · high)");
   });
 
   it("shows model and concrete thinking level for a running agent in compact mode", () => {
@@ -676,7 +756,7 @@ describe("model and thinking labels", () => {
 
     const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
     expect(lines).toHaveLength(2);
-    expect(lines[1]).toContain("(sonnet · thinking: high)");
+    expect(lines[1]).toContain("(sonnet · high)");
   });
 
   it("shows model and concrete thinking level for a finished agent", () => {
@@ -685,7 +765,7 @@ describe("model and thinking labels", () => {
     (manager as any).listAgents = () => [agent];
 
     const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
-    expect(lines[1]).toContain("(sonnet · thinking: high)");
+    expect(lines[1]).toContain("(sonnet · high)");
   });
 
   it("does not invent a model when none was captured", () => {
@@ -695,7 +775,8 @@ describe("model and thinking labels", () => {
     (manager as any).listAgents = () => [agent];
 
     const lines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
-    expect(lines[1]).toContain("(thinking: high)");
+    expect(lines[1]).toContain("(high)");
+    expect(lines[1]).not.toContain("thinking:");
     expect(lines[1]).not.toContain("undefined");
   });
 
@@ -734,10 +815,10 @@ describe("model and thinking labels", () => {
     widget.navActivate();
 
     const stripMockStyling = (line: string) => line
-      .replace(/\[(?:accent|dim|success|error|warning|muted):/g, "")
+      .replace(/\[(?:accent|dim|text|success|error|warning|muted):/g, "")
       .replaceAll("]", "")
       .replaceAll("**", "");
-    const labelWidth = "(very-long-model · thinking: high)".length;
+    const labelWidth = "(very-long-model · high)".length;
     const nameWidth = "Explore".length;
     const assertColumnGaps = (line: string, name: string, label: string, description: string) => {
       const plain = stripMockStyling(line);
@@ -752,7 +833,7 @@ describe("model and thinking labels", () => {
 
     const fullLines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
     const finishedHeader = assertColumnGaps(findHeader(fullLines, "Finished description"), "Explore", "(haiku)", "Finished description");
-    const runningHeader = assertColumnGaps(findHeader(fullLines, "Running description"), "Builder", "(very-long-model · thinking: high)", "Running description");
+    const runningHeader = assertColumnGaps(findHeader(fullLines, "Running description"), "Builder", "(very-long-model · high)", "Running description");
     assertColumnGaps(findHeader(fullLines, "Queued description"), "Queue", "(sonnet)", "Queued description");
     expect(finishedHeader.indexOf("Finished description")).toBe(runningHeader.indexOf("Running description"));
     expect(finishedHeader.indexOf("10⚙︎")).toBe(runningHeader.indexOf("5⚙︎"));
@@ -760,7 +841,7 @@ describe("model and thinking labels", () => {
     widget.setCompactMode(true);
     widget.setWidgetShortcut(true);
     const compactLines = (widget as any).renderWidget(makeMockTUI(), makeMockTheme());
-    assertColumnGaps(findHeader(compactLines, "Running description"), "Builder", "(very-long-model · thinking: high)", "Running description");
+    assertColumnGaps(findHeader(compactLines, "Running description"), "Builder", "(very-long-model · high)", "Running description");
 
     finished.display.invocation = undefined;
     running.display.invocation = undefined;

--- a/test/ui/conversation-viewer.test.ts
+++ b/test/ui/conversation-viewer.test.ts
@@ -497,6 +497,20 @@ describe("ConversationViewer", () => {
       expect(header).not.toContain("$");
     });
 
+    it("separates stats groups with two spaces while retaining metadata separators", () => {
+      const session = makeMockSession();
+      const record = makeMockRecord({ execution: { session } });
+      record.display.invocation = { modelName: "sonnet", thinkingLevel: "high", runInBackground: true };
+      const viewer = new ConversationViewer(makeTui(), session, record, noopTheme, vi.fn());
+
+      const statsLine = viewer.render(120).find(line => line.includes("5⚙︎"))!;
+
+      expect(statsLine).toContain("sonnet · high · 5⚙︎  10⟳  ↑12k ↓8.0k W3.0k $0.024");
+      expect(statsLine).not.toContain("5⚙︎ ·");
+      expect(statsLine).not.toContain("10⟳ ·");
+      expect(statsLine).toContain(" · background");
+    });
+
     it("renders the thinking level immediately after the model", () => {
       const session = makeMockSession();
       const record = makeMockRecord({ execution: { session } });

--- a/test/ui/conversation-viewer.test.ts
+++ b/test/ui/conversation-viewer.test.ts
@@ -505,7 +505,7 @@ describe("ConversationViewer", () => {
 
       const modelLine = viewer.render(120).find(line => line.includes("sonnet"));
 
-      expect(modelLine).toContain("sonnet · thinking: high · 5⚙︎");
+      expect(modelLine).toContain("sonnet · high · 5⚙︎");
       expect(modelLine).toContain("background");
     });
 
@@ -515,9 +515,9 @@ describe("ConversationViewer", () => {
       record.display.invocation = { thinkingLevel: "high" };
       const viewer = new ConversationViewer(makeTui(), session, record, noopTheme, vi.fn());
 
-      const statsLine = viewer.render(120).find(line => line.includes("thinking: high"));
+      const statsLine = viewer.render(120).find(line => line.includes("high · 5⚙︎"));
 
-      expect(statsLine).toContain("thinking: high · 5⚙︎");
+      expect(statsLine).toContain("high · 5⚙︎");
       expect(statsLine).not.toContain("undefined");
     });
 
@@ -527,7 +527,7 @@ describe("ConversationViewer", () => {
       record.display.invocation = { modelName: "sonnet", thinkingLevel: "inherit" };
       const viewer = new ConversationViewer(makeTui(), session, record, noopTheme, vi.fn());
 
-      expect(viewer.render(120).join("\n")).not.toContain("thinking:");
+      expect(viewer.render(120).join("\n")).not.toContain("inherit");
     });
 
     it("renders user messages", () => {

--- a/test/ui/conversation-viewer.test.ts
+++ b/test/ui/conversation-viewer.test.ts
@@ -475,7 +475,7 @@ describe("ConversationViewer", () => {
 
       const modelLine = viewer.render(120).find(line => line.includes("sonnet"));
 
-      expect(modelLine).toContain("sonnet · thinking: high · 5🛠");
+      expect(modelLine).toContain("sonnet · thinking: high · 5⚙︎");
       expect(modelLine).toContain("background");
     });
 
@@ -487,7 +487,7 @@ describe("ConversationViewer", () => {
 
       const statsLine = viewer.render(120).find(line => line.includes("thinking: high"));
 
-      expect(statsLine).toContain("thinking: high · 5🛠");
+      expect(statsLine).toContain("thinking: high · 5⚙︎");
       expect(statsLine).not.toContain("undefined");
     });
 

--- a/test/ui/conversation-viewer.test.ts
+++ b/test/ui/conversation-viewer.test.ts
@@ -467,6 +467,36 @@ describe("ConversationViewer", () => {
       expect(lines[lines.length - 1]).toMatch(/[╰]/);
     });
 
+    it.each([
+      ["completed", "✓"],
+      ["turn_limited", "✓"],
+      ["stopped", "■"],
+      ["error", "✗"],
+      ["aborted", "✗"],
+    ] as const)("uses the shared %s status icon", (status, icon) => {
+      const session = makeMockSession();
+      const record = makeMockRecord({ lifecycle: { status, startedAt: Date.now() - 30000, completedAt: Date.now() } });
+      const viewer = new ConversationViewer(makeTui(), session, record, noopTheme, vi.fn());
+
+      expect(viewer.render(120)[1]).toContain(icon);
+    });
+
+    it("honors configured stats visibility in its header", () => {
+      const session = makeMockSession();
+      const record = makeMockRecord({ execution: { session } });
+      const viewer = new ConversationViewer(
+        makeTui(), session, record, noopTheme, vi.fn(), undefined, undefined, undefined,
+        { showTools: false, showTurns: false, showInput: false, showOutput: false, showContext: false, showCost: false, showTime: false },
+      );
+
+      const header = viewer.render(120).slice(1, 3).join("\n");
+      expect(header).not.toContain("⚙︎");
+      expect(header).not.toContain("⟳");
+      expect(header).not.toContain("↑");
+      expect(header).not.toContain("↓");
+      expect(header).not.toContain("$");
+    });
+
     it("renders the thinking level immediately after the model", () => {
       const session = makeMockSession();
       const record = makeMockRecord({ execution: { session } });

--- a/test/ui/conversation-viewer.test.ts
+++ b/test/ui/conversation-viewer.test.ts
@@ -467,6 +467,39 @@ describe("ConversationViewer", () => {
       expect(lines[lines.length - 1]).toMatch(/[╰]/);
     });
 
+    it("renders the thinking level immediately after the model", () => {
+      const session = makeMockSession();
+      const record = makeMockRecord({ execution: { session } });
+      record.display.invocation = { modelName: "sonnet", thinkingLevel: "high", runInBackground: true };
+      const viewer = new ConversationViewer(makeTui(), session, record, noopTheme, vi.fn());
+
+      const modelLine = viewer.render(120).find(line => line.includes("sonnet"));
+
+      expect(modelLine).toContain("sonnet · thinking: high · 5🛠");
+      expect(modelLine).toContain("background");
+    });
+
+    it("renders concrete thinking without inventing a model", () => {
+      const session = makeMockSession();
+      const record = makeMockRecord({ execution: { session } });
+      record.display.invocation = { thinkingLevel: "high" };
+      const viewer = new ConversationViewer(makeTui(), session, record, noopTheme, vi.fn());
+
+      const statsLine = viewer.render(120).find(line => line.includes("thinking: high"));
+
+      expect(statsLine).toContain("thinking: high · 5🛠");
+      expect(statsLine).not.toContain("undefined");
+    });
+
+    it("does not render an inherited thinking level", () => {
+      const session = makeMockSession();
+      const record = makeMockRecord({ execution: { session } });
+      record.display.invocation = { modelName: "sonnet", thinkingLevel: "inherit" };
+      const viewer = new ConversationViewer(makeTui(), session, record, noopTheme, vi.fn());
+
+      expect(viewer.render(120).join("\n")).not.toContain("thinking:");
+    });
+
     it("renders user messages", () => {
       const session = makeMockSession([{ role: "user", content: "hello world" }]);
       const record = makeMockRecord({ execution: { session } });
@@ -599,6 +632,29 @@ describe("ConversationViewer", () => {
       const text = lines.join("\n");
 
       expect(text).not.toContain("@");
+    });
+
+    it("uses the persisted Pi usage snapshot after completion", () => {
+      const session = makeMockSession([{ role: "user", content: "hello" }]);
+      const record = makeMockRecord({
+        lifecycle: { status: "completed", startedAt: 0, completedAt: 1000 },
+        execution: { session },
+        stats: {
+          lifetimeUsage: { input: 83000, output: 7100, cacheWrite: 12000, cost: 1.262 },
+          cacheRead: 1300000,
+          latestCacheHitRate: 99.1,
+          contextPercent: 23.4,
+          contextWindow: 272000,
+          autoCompactionEnabled: true,
+          usingSubscription: true,
+          toolUses: 5,
+          turnCount: 10,
+          compactionCount: 7,
+        },
+      });
+      const viewer = new ConversationViewer(makeTui(), session, record, noopTheme, vi.fn());
+      expect(viewer.render(200).join("\n"))
+        .toContain("↑83k ↓7.1k R1.3M W12k CH99.1% $1.262 (sub) 23.4%/272k (auto)");
     });
   });
 

--- a/test/ui/conversation-viewer.test.ts
+++ b/test/ui/conversation-viewer.test.ts
@@ -497,7 +497,7 @@ describe("ConversationViewer", () => {
       expect(header).not.toContain("$");
     });
 
-    it("separates stats groups with two spaces while retaining metadata separators", () => {
+    it("uses the shared single-row stats grouping while retaining metadata separators", () => {
       const session = makeMockSession();
       const record = makeMockRecord({ execution: { session } });
       record.display.invocation = { modelName: "sonnet", thinkingLevel: "high", runInBackground: true };
@@ -505,9 +505,9 @@ describe("ConversationViewer", () => {
 
       const statsLine = viewer.render(120).find(line => line.includes("5⚙︎"))!;
 
-      expect(statsLine).toContain("sonnet · high · 5⚙︎  10⟳  ↑12k ↓8.0k W3.0k $0.024");
-      expect(statsLine).not.toContain("5⚙︎ ·");
-      expect(statsLine).not.toContain("10⟳ ·");
+      expect(statsLine).toContain("sonnet · high · 5⚙︎  10⟳ · ↑12k ↓8.0k W3.0k $0.024 · 30s");
+      expect(statsLine).not.toContain("5⚙︎ · 10⟳");
+      expect(statsLine).toContain("10⟳ · ↑12k");
       expect(statsLine).toContain(" · background");
     });
 

--- a/test/ui/format.test.ts
+++ b/test/ui/format.test.ts
@@ -186,12 +186,13 @@ describe("buildInvocationTags", () => {
   it("returns a concrete thinking tag separately from other invocation tags", () => {
     expect(buildInvocationTags({ modelName: "sonnet", thinkingLevel: "high", runInBackground: true, maxTurns: 10 })).toEqual({
       modelName: "sonnet",
-      thinkingTag: "thinking: high",
+      thinkingTag: "high",
       tags: ["background", "max turns: 10"],
     });
   });
 
-  it("does not format inherited or invalid thinking values", () => {
+  it("formats concrete levels compactly and omits inherited or invalid values", () => {
+    expect(formatThinkingTag("high")).toBe("high");
     expect(formatThinkingTag("inherit")).toBeUndefined();
     expect(formatThinkingTag("unknown")).toBeUndefined();
   });

--- a/test/ui/format.test.ts
+++ b/test/ui/format.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { buildInvocationTags, buildStatsParts, formatThinkingTag, formatUsageBlock } from "../../src/ui/format.js";
+import { buildInvocationTags, buildStatsParts, formatThinkingTag, formatUsageBlock, getAgentStatusDisplay } from "../../src/ui/format.js";
 
 const mockTheme = {
   fg: (_color: string, text: string) => text,
@@ -29,6 +29,18 @@ const allStats = {
   cost: 1.23,
   durationMs: 65000,
 };
+
+describe("getAgentStatusDisplay", () => {
+  it.each([
+    ["completed", "✓"],
+    ["turn_limited", "✓"],
+    ["stopped", "■"],
+    ["error", "✗"],
+    ["aborted", "✗"],
+  ] as const)("maps %s to %s", (status, icon) => {
+    expect(getAgentStatusDisplay(status).icon).toBe(icon);
+  });
+});
 
 describe("buildStatsParts — visible flag: showTools", () => {
   it("excludes toolUses when showTools is false", () => {

--- a/test/ui/format.test.ts
+++ b/test/ui/format.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { buildStatsParts } from "../../src/ui/format.js";
+import { buildInvocationTags, buildStatsParts, formatThinkingTag, formatUsageBlock } from "../../src/ui/format.js";
 
 const mockTheme = {
   fg: (_color: string, text: string) => text,
@@ -21,7 +21,11 @@ const allStats = {
   input: 1000,
   output: 500,
   contextPercent: 50,
-  compactions: 2,
+  contextWindow: 272000,
+  autoCompactionEnabled: true,
+  cacheRead: 1300000,
+  cacheWrite: 12000,
+  latestCacheHitRate: 99.1,
   cost: 1.23,
   durationMs: 65000,
 };
@@ -70,16 +74,44 @@ describe("buildStatsParts — visible flag: showInput/showOutput", () => {
 });
 
 describe("buildStatsParts — visible flag: showContext", () => {
-  it("excludes context percent and compactions when showContext is false", () => {
-    const parts = buildStatsParts(allStats, mockTheme, { showContext: false });
-    expect(parts.some(p => p.includes("%"))).toBe(false);
-    expect(parts.some(p => p.includes("↻"))).toBe(false);
+  it("excludes context/window/auto when showContext is false", () => {
+    expect(buildStatsParts(allStats, mockTheme, { showContext: false }).join(" · "))
+      .toBe("5🛠 · 3⟳ · ↑1.0k ↓500 R1.3M W12k CH99.1% $1.230 · 1m 5s");
   });
 
-  it("includes context percent when showContext is true (default)", () => {
-    const parts = buildStatsParts(allStats, mockTheme);
-    expect(parts.some(p => p.includes("%"))).toBe(true);
-    expect(parts.some(p => p.includes("↻"))).toBe(true);
+  it("includes Pi context/window/auto but keeps compaction tracking out of usage", () => {
+    expect(buildStatsParts(allStats, mockTheme).join(" · "))
+      .toBe("5🛠 · 3⟳ · ↑1.0k ↓500 R1.3M W12k CH99.1% $1.230 50.0%/272k (auto) · 1m 5s");
+  });
+});
+
+describe("buildStatsParts — Pi context colors", () => {
+  const markerTheme = {
+    fg: (color: string, text: string) => `[${color}:${text}]`,
+    bold: (text: string) => text,
+  };
+
+  it("uses Pi's strict warning and error context thresholds without splitting usage spacing", () => {
+    const usageAt = (contextPercent: number | null) => buildStatsParts(
+      { ...allStats, contextPercent }, markerTheme,
+    ).at(2)!;
+
+    expect(usageAt(null)).toContain("?/272k (auto)");
+    expect(usageAt(null)).not.toMatch(/\[(?:warning|error):/);
+    expect(usageAt(70.0)).toContain("70.0%/272k (auto)");
+    expect(usageAt(70.0)).not.toMatch(/\[(?:warning|error):/);
+    expect(usageAt(70.1)).toContain("[warning:70.1%/272k (auto)]");
+    expect(usageAt(90.0)).toContain("[warning:90.0%/272k (auto)]");
+    expect(usageAt(90.1)).toContain("[error:90.1%/272k (auto)]");
+    expect(usageAt(90.1)).toBe("↑1.0k ↓500 R1.3M W12k CH99.1% $1.230 [error:90.1%/272k (auto)]");
+  });
+
+  it("uses Pi's zero-window fallback only when context percent is known", () => {
+    expect(formatUsageBlock({ input: 0, output: 0, contextPercent: 70.1 }, undefined, markerTheme))
+      .toBe("[warning:70.1%/0]");
+    expect(formatUsageBlock({ input: 0, output: 0, contextPercent: 90.1 }, undefined, markerTheme))
+      .toBe("[error:90.1%/0]");
+    expect(formatUsageBlock({ input: 0, output: 0 })).toBeUndefined();
   });
 });
 
@@ -138,7 +170,56 @@ describe("buildStatsParts — backward compatibility", () => {
   });
 });
 
-describe("buildStatsParts — cost behavior", () => {
+describe("buildInvocationTags", () => {
+  it("returns a concrete thinking tag separately from other invocation tags", () => {
+    expect(buildInvocationTags({ modelName: "sonnet", thinkingLevel: "high", runInBackground: true, maxTurns: 10 })).toEqual({
+      modelName: "sonnet",
+      thinkingTag: "thinking: high",
+      tags: ["background", "max turns: 10"],
+    });
+  });
+
+  it("does not format inherited or invalid thinking values", () => {
+    expect(formatThinkingTag("inherit")).toBeUndefined();
+    expect(formatThinkingTag("unknown")).toBeUndefined();
+  });
+});
+
+describe("formatUsageBlock — Pi ordering and visibility", () => {
+  const usage = {
+    input: 83_000,
+    output: 7_100,
+    cacheRead: 1_300_000,
+    cacheWrite: 12_000,
+    latestCacheHitRate: 99.1,
+    cost: 1.262,
+    usingSubscription: true,
+    contextPercent: 23.4,
+    contextWindow: 272_000,
+    autoCompactionEnabled: true,
+  };
+
+  it("matches Pi's complete space-separated sequence", () => {
+    expect(formatUsageBlock(usage)).toBe("↑83k ↓7.1k R1.3M W12k CH99.1% $1.262 (sub) 23.4%/272k (auto)");
+  });
+
+  it("uses unknown context without inventing a percentage", () => {
+    expect(formatUsageBlock({ ...usage, contextPercent: null }))
+      .toBe("↑83k ↓7.1k R1.3M W12k CH99.1% $1.262 (sub) ?/272k (auto)");
+  });
+
+  it("honors input, output, context, and cost visibility independently", () => {
+    expect(formatUsageBlock(usage, { showInput: false, showContext: false, showCost: false }))
+      .toBe("↓7.1k");
+  });
+
+  it("shows the zero subscription cost like Pi", () => {
+    expect(formatUsageBlock({ ...usage, cost: 0, input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }))
+      .toBe("$0.000 (sub) 23.4%/272k (auto)");
+  });
+});
+
+describe("buildStatsParts — cost behavior",  () => {
   it("does not include cost when not provided", () => {
     const parts = buildStatsParts({
       toolUses: 5, turnCount: 3, maxTurns: 30, input: 1000, output: 500,
@@ -152,8 +233,7 @@ describe("buildStatsParts — cost behavior", () => {
     expect(parts.some(p => p.includes("$"))).toBe(false);
   });
 
-  it("includes cost formatted as dollar amount", () => {
-    const parts = buildStatsParts(allStats, mockTheme);
-    expect(parts.some(p => /^\$\d+\.\d{2}$/.test(p))).toBe(true);
+  it("includes a three-decimal cost in the contiguous usage group", () => {
+    expect(buildStatsParts(allStats, mockTheme).at(2)).toContain("$1.230");
   });
 });

--- a/test/ui/format.test.ts
+++ b/test/ui/format.test.ts
@@ -7,7 +7,8 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { buildInvocationTags, buildStatsParts, formatThinkingTag, formatUsageBlock, getAgentStatusDisplay } from "../../src/ui/format.js";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { buildInvocationTags, buildStatsCells, buildStatsLayout, buildStatsParts, formatStatsRow, formatThinkingTag, formatUsageBlock, getAgentStatusDisplay } from "../../src/ui/format.js";
 
 const mockTheme = {
   fg: (_color: string, text: string) => text,
@@ -168,6 +169,32 @@ describe("buildStatsParts — all visible flags false", () => {
       showTime: false,
     });
     expect(parts).toEqual([]);
+  });
+});
+
+describe("structured stats rows", () => {
+  it("uses counter, Pi footer, and duration groups in the single-row formatter", () => {
+    const cells = buildStatsCells({ ...allStats, durationMs: 30_000 }, mockTheme);
+    expect(formatStatsRow(cells)).toBe("5⚙︎  3⟳ · ↑1.0k ↓500 R1.3M W12k CH99.1% $1.230 50.0%/272k (auto) · 30s");
+  });
+
+  it("reserves optional Pi metric slots and measures ANSI styling by visible width", () => {
+    const ansiTheme = {
+      fg: (color: string, text: string) => color === "error" ? `\u001b[31m${text}\u001b[39m` : text,
+      bold: (text: string) => text,
+    };
+    const rows = [
+      buildStatsCells({ ...allStats, toolUses: 22, turnCount: 13, contextPercent: 90.1, durationMs: 147_000 }, ansiTheme),
+      buildStatsCells({ ...allStats, toolUses: 9, turnCount: 2, cacheWrite: 0, contextPercent: 20, durationMs: 89_000 }, ansiTheme),
+    ];
+    const rendered = rows.map((row) => formatStatsRow(row, buildStatsLayout(rows))!);
+
+    expect(rendered[0]).toContain("22⚙︎  13⟳ ·");
+    expect(rendered[1]).toContain(" 9⚙︎   2⟳ ·");
+    expect(rendered[0]).toContain("\u001b[31m90.1%/272k (auto)\u001b[39m");
+    const start = (line: string, text: string) => visibleWidth(line.slice(0, line.indexOf(text)));
+    expect(start(rendered[1], "$1.230")).toBe(start(rendered[0], "$1.230"));
+    expect(start(rendered[1], "1m 29s")).toBe(start(rendered[0], "2m 27s"));
   });
 });
 

--- a/test/ui/format.test.ts
+++ b/test/ui/format.test.ts
@@ -33,12 +33,12 @@ const allStats = {
 describe("buildStatsParts — visible flag: showTools", () => {
   it("excludes toolUses when showTools is false", () => {
     const parts = buildStatsParts(allStats, mockTheme, { showTools: false });
-    expect(parts.some(p => p.includes("🛠"))).toBe(false);
+    expect(parts.some(p => p.includes("⚙︎"))).toBe(false);
   });
 
   it("includes toolUses when showTools is true (default)", () => {
     const parts = buildStatsParts(allStats, mockTheme);
-    expect(parts.some(p => p.includes("🛠"))).toBe(true);
+    expect(parts.some(p => p.includes("⚙︎"))).toBe(true);
   });
 });
 
@@ -76,12 +76,12 @@ describe("buildStatsParts — visible flag: showInput/showOutput", () => {
 describe("buildStatsParts — visible flag: showContext", () => {
   it("excludes context/window/auto when showContext is false", () => {
     expect(buildStatsParts(allStats, mockTheme, { showContext: false }).join(" · "))
-      .toBe("5🛠 · 3⟳ · ↑1.0k ↓500 R1.3M W12k CH99.1% $1.230 · 1m 5s");
+      .toBe("5⚙︎ · 3⟳ · ↑1.0k ↓500 R1.3M W12k CH99.1% $1.230 · 1m 5s");
   });
 
   it("includes Pi context/window/auto but keeps compaction tracking out of usage", () => {
     expect(buildStatsParts(allStats, mockTheme).join(" · "))
-      .toBe("5🛠 · 3⟳ · ↑1.0k ↓500 R1.3M W12k CH99.1% $1.230 50.0%/272k (auto) · 1m 5s");
+      .toBe("5⚙︎ · 3⟳ · ↑1.0k ↓500 R1.3M W12k CH99.1% $1.230 50.0%/272k (auto) · 1m 5s");
   });
 });
 
@@ -163,7 +163,7 @@ describe("buildStatsParts — backward compatibility", () => {
   it("without visible parameter, behaves the same as before", () => {
     const parts = buildStatsParts(allStats, mockTheme);
     expect(parts.length).toBeGreaterThan(0);
-    expect(parts.some(p => p.includes("🛠"))).toBe(true);
+    expect(parts.some(p => p.includes("⚙︎"))).toBe(true);
     expect(parts.some(p => p.includes("⟳"))).toBe(true);
     expect(parts.some(p => p.includes("↑"))).toBe(true);
     expect(parts.some(p => p.includes("$"))).toBe(true);

--- a/test/ui/menu/menu-running-agents.test.ts
+++ b/test/ui/menu/menu-running-agents.test.ts
@@ -6,7 +6,7 @@
  * Selecting an agent opens an actions submenu (also SelectList).
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mockModules } from "../../menu-mock-setup.js";
 import { createMockCtx } from "../../menu-test-helpers.js";
 
@@ -54,6 +54,7 @@ vi.mock("@earendil-works/pi-tui", () => ({
 
 // Import AFTER mock setup
 import { showRunningAgentsMenu, buildAgentActionsList } from "../../../src/ui/menu/menu-running-agents.js";
+import { getDisplayName } from "../../../src/ui/format.js";
 
 function makeRecord(overrides: any = {}): any {
   return {
@@ -69,10 +70,15 @@ function makeRecord(overrides: any = {}): any {
 }
 const noopTheme = { fg: (_c: string, t: string) => t, bold: (t: string) => t };
 
+afterEach(() => {
+  vi.mocked(getDisplayName).mockImplementation((type) => type);
+});
+
 describe("showRunningAgentsMenu — SelectList migration", () => {
   beforeEach(() => {
     selectListCalls = [];
     vi.clearAllMocks();
+    vi.mocked(getDisplayName).mockImplementation((type) => type);
     mockModules.mockManager.listAgents.mockReset().mockReturnValue([]);
   });
 
@@ -105,13 +111,28 @@ describe("showRunningAgentsMenu — SelectList migration", () => {
     expect(selectListCalls[0].items[1].value).toBe("agent-2");
   });
 
-  it("includes agent type in label", async () => {
-    mockModules.mockManager.listAgents.mockReturnValue([
-      makeRecord({ id: "agent-1", display: { type: "general-purpose", description: "Test" } }),
-    ]);
-    const ctx = createMockCtx();
-    await showRunningAgentsMenu(ctx);
-    expect(selectListCalls[0].items[0].label).toContain("general-purpose");
+  it("uses the configured display name and shared lifecycle icons in labels", async () => {
+    vi.mocked(getDisplayName).mockImplementation((type) => `Display ${type}`);
+    const statuses = [
+      ["completed", "✓"],
+      ["turn_limited", "✓"],
+      ["stopped", "■"],
+      ["error", "✗"],
+      ["aborted", "✗"],
+    ] as const;
+    mockModules.mockManager.listAgents.mockReturnValue(statuses.map(([status], index) =>
+      makeRecord({ id: `agent-${index}`, display: { type: "custom", description: "Test" }, lifecycle: { status, startedAt: Date.now() - 1000 } }),
+    ));
+
+    await showRunningAgentsMenu(createMockCtx());
+
+    const labels = selectListCalls[0].items.map((item: any) => item.label);
+    expect(labels).toHaveLength(statuses.length);
+    for (const [status, icon] of statuses) {
+      const label = labels.find((value: string) => value.includes(` ${status} `));
+      expect(label).toContain(`Display custom  ${status}`);
+      expect(label.startsWith(icon)).toBe(true);
+    }
   });
 
   it("returns a component that renders with a title", async () => {

--- a/test/ui/menu/menu-widget-settings.test.ts
+++ b/test/ui/menu/menu-widget-settings.test.ts
@@ -91,6 +91,31 @@ describe("showWidgetSettingsMenu — SettingsList integration", () => {
     const compact = settingsListCalls[0].items.find((i: any) => i.id === "compact");
     expect(compact.currentValue).toBe("ON");
   });
+
+  it("shows navigation hint with its configured value", async () => {
+    mockModules.mockConfig.agent.widgetNavHint = false;
+    const ctx = createMockCtx();
+    await showWidgetSettingsMenu(ctx);
+    const navHint = settingsListCalls[0].items.find((i: any) => i.id === "navHint");
+    expect(navHint.currentValue).toBe("OFF");
+  });
+
+  it("shows model and thinking with its configured value", async () => {
+    mockModules.mockConfig.agent.widgetShowModelThinking = false;
+    const ctx = createMockCtx();
+    await showWidgetSettingsMenu(ctx);
+    const modelThinking = settingsListCalls[0].items.find((i: any) => i.id === "showModelThinking");
+    expect(modelThinking.label).toBe("Show model & thinking");
+    expect(modelThinking.currentValue).toBe("OFF");
+  });
+
+  it("shows local start time with its configured value", async () => {
+    mockModules.mockConfig.agent.widgetShowStartTime = false;
+    const ctx = createMockCtx();
+    await showWidgetSettingsMenu(ctx);
+    const startTime = settingsListCalls[0].items.find((i: any) => i.id === "showStartTime");
+    expect(startTime.currentValue).toBe("OFF");
+  });
 });
 
 describe("showWidgetSettingsMenu — toggle onChange", () => {
@@ -127,6 +152,20 @@ describe("showWidgetSettingsMenu — toggle onChange", () => {
     settingsListCalls[0].onChange("shortcut", "ON");
     expect(mockModules.mockConfig.agent.widgetShortcut).toBe(true);
     expect(ctx.ui.notify).toHaveBeenCalledWith(expect.any(String), "info");
+  });
+
+  it("toggles model and thinking, local start time, and navigation hint via onChange", async () => {
+    const ctx = createMockCtx();
+    await showWidgetSettingsMenu(ctx);
+    settingsListCalls[0].onChange("showModelThinking", "OFF");
+    settingsListCalls[0].onChange("showStartTime", "OFF");
+    settingsListCalls[0].onChange("navHint", "OFF");
+    expect(mockModules.mockConfig.agent.widgetShowModelThinking).toBe(false);
+    expect(mockModules.mockConfig.agent.widgetShowStartTime).toBe(false);
+    expect(mockModules.mockConfig.agent.widgetNavHint).toBe(false);
+    expect(ctx.ui.notify).toHaveBeenCalledWith("Show model & thinking OFF", "info");
+    expect(ctx.ui.notify).toHaveBeenCalledWith("Show local start time OFF", "info");
+    expect(ctx.ui.notify).toHaveBeenCalledWith("Navigation hint OFF", "info");
   });
 });
 
@@ -211,7 +250,7 @@ describe("showWidgetSettingsMenu — numeric submenu", () => {
     expect(mockDone).toHaveBeenCalled();
   });
 
-  it("compact max lines submenu rejects value below 1", async () => {
+  it("compact max lines submenu rejects values below 2", async () => {
     mockModules.mockConfig.agent.widgetMaxLinesCompact = 6;
     const ctx = createMockCtx();
     await showWidgetSettingsMenu(ctx);
@@ -220,7 +259,7 @@ describe("showWidgetSettingsMenu — numeric submenu", () => {
     const mockDone = vi.fn();
     maxLinesCompact.submenu("6", mockDone);
 
-    inputInstances[0].onSubmit!("0");
+    inputInstances[0].onSubmit!("1");
     expect(mockModules.mockConfig.agent.widgetMaxLinesCompact).toBe(6);
     expect(ctx.ui.notify).toHaveBeenCalledWith(expect.any(String), "error");
   });

--- a/test/ui/renderer-stats.test.ts
+++ b/test/ui/renderer-stats.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { buildStatsLine } from "../../src/ui/renderer.js";
+
+const theme = {
+  fg: (_color: string, text: string) => text,
+  bold: (text: string) => text,
+};
+
+describe("renderer stats", () => {
+  it("uses the structured single-row counter, Pi footer, and duration groups", () => {
+    expect(buildStatsLine({
+      toolUses: 5,
+      turnCount: 10,
+      input: 12_000,
+      output: 8_000,
+      cacheRead: 85_000,
+      cacheWrite: 3_000,
+      latestCacheHitRate: 89.2,
+      contextPercent: 47,
+      contextWindow: 128_000,
+      cost: 0.024,
+      durationMs: 30_000,
+    }, theme as any, true)).toBe(
+      "5⚙︎  10⟳ · ↑12k ↓8.0k R85k W3.0k CH89.2% $0.024 47.0%/128k · 30s",
+    );
+  });
+});

--- a/test/ui/renderer.test.ts
+++ b/test/ui/renderer.test.ts
@@ -39,11 +39,12 @@ vi.mock("@earendil-works/pi-tui", () => ({
 vi.mock("../../src/ui/format.js", () => ({
   buildStatsParts: vi.fn(() => ["5 uses", "3 turns"]),
   formatMs: vi.fn(() => "1m0s"),
+  formatThinkingTag: vi.fn((value: unknown) => value === "high" ? "thinking: high" : undefined),
   getDisplayName: vi.fn((type: string) => type.charAt(0).toUpperCase() + type.slice(1)),
 }));
 
 // Import after mocks are set up
-import { renderSubagentResult } from "../../src/ui/renderer.js";
+import { renderAgentToolCall, renderAgentToolResult, renderSubagentResult } from "../../src/ui/renderer.js";
 
 /* ------------------------------------------------------------------ */
 /*  Helpers                                                           */
@@ -61,9 +62,47 @@ const SHOW_COST = false;
 /*  Tests                                                             */
 /* ------------------------------------------------------------------ */
 
-describe("renderSubagentResult — worktree path display", () => {
+describe("renderer", () => {
   beforeEach(() => {
     textInstances.length = 0;
+  });
+
+  it("shows thinking level directly after the model in a normal tool call", () => {
+    renderAgentToolCall({ agent: "builder", _modelOverride: "sonnet", thinking: "high" }, noopTheme);
+
+    expect(textInstances.at(-1)?.text).toBe("▸ Builder (sonnet · thinking: high)");
+  });
+
+  it("shows concrete thinking without a model override in a tool call", () => {
+    renderAgentToolCall({ agent: "agent", thinking: "high" }, noopTheme);
+
+    expect(textInstances.at(-1)?.text).toBe("▸ Agent (thinking: high)");
+  });
+
+  it("keeps the normal tool call unchanged without a concrete thinking level", () => {
+    renderAgentToolCall({ agent: "builder", _modelOverride: "sonnet", thinking: "inherit" }, noopTheme);
+
+    expect(textInstances.at(-1)?.text).toBe("▸ Builder (sonnet)");
+  });
+
+  it("shows thinking level directly after the model in an agent result card", () => {
+    renderAgentToolResult({
+      content: [{ type: "text", text: "Agent output" }],
+      details: { type: "builder", description: "Build something", modelName: "sonnet", thinkingLevel: "high", turnCount: 5 },
+    }, { expanded: false }, noopTheme, SHOW_COST);
+
+    expect(textInstances.map((t) => t.text).join("\n")).toContain("Builder (sonnet · thinking: high)");
+  });
+
+  it("shows concrete thinking without inventing a model in a foreground result card", () => {
+    renderAgentToolResult({
+      content: [{ type: "text", text: "Agent output" }],
+      details: { type: "builder", description: "Build something", thinkingLevel: "high", turnCount: 5 },
+    }, { expanded: false }, noopTheme, SHOW_COST);
+
+    const text = textInstances.map((t) => t.text).join("\n");
+    expect(text).toContain("Builder (thinking: high)");
+    expect(text).not.toContain("undefined");
   });
 
   it("shows worktree path in details pane for a completed agent with stats", () => {
@@ -82,6 +121,35 @@ describe("renderSubagentResult — worktree path display", () => {
 
     const allText = textInstances.map((t) => t.text).join("\n");
     expect(allText).toContain("worktree: /wt/feature");
+  });
+
+  it("shows thinking level directly after the model in a subagent result card", () => {
+    const message = {
+      content: "Agent output",
+      details: {
+        type: "builder",
+        description: "Build something",
+        modelName: "sonnet",
+        thinkingLevel: "high",
+        turnCount: 5,
+        status: "completed",
+      },
+    };
+
+    renderSubagentResult(message, { expanded: false }, noopTheme, SHOW_COST);
+
+    expect(textInstances.map((t) => t.text).join("\n")).toContain("Builder (sonnet · thinking: high)");
+  });
+
+  it("shows concrete thinking without inventing a model in a background result card", () => {
+    renderSubagentResult({
+      content: "Agent output",
+      details: { type: "builder", description: "Build something", thinkingLevel: "high", turnCount: 5, status: "completed" },
+    }, { expanded: false }, noopTheme, SHOW_COST);
+
+    const text = textInstances.map((t) => t.text).join("\n");
+    expect(text).toContain("Builder (thinking: high)");
+    expect(text).not.toContain("undefined");
   });
 
   it("shows worktree path in fallback result line (no turnCount)", () => {

--- a/test/ui/renderer.test.ts
+++ b/test/ui/renderer.test.ts
@@ -39,7 +39,7 @@ vi.mock("@earendil-works/pi-tui", () => ({
 vi.mock("../../src/ui/format.js", () => ({
   buildStatsParts: vi.fn(() => ["5 uses", "3 turns"]),
   formatMs: vi.fn(() => "1m0s"),
-  formatThinkingTag: vi.fn((value: unknown) => value === "high" ? "thinking: high" : undefined),
+  formatThinkingTag: vi.fn((value: unknown) => value === "high" ? "high" : undefined),
   getDisplayName: vi.fn((type: string) => type.charAt(0).toUpperCase() + type.slice(1)),
 }));
 
@@ -70,13 +70,13 @@ describe("renderer", () => {
   it("shows thinking level directly after the model in a normal tool call", () => {
     renderAgentToolCall({ agent: "builder", _modelOverride: "sonnet", thinking: "high" }, noopTheme);
 
-    expect(textInstances.at(-1)?.text).toBe("▸ Builder (sonnet · thinking: high)");
+    expect(textInstances.at(-1)?.text).toBe("▸ Builder (sonnet · high)");
   });
 
   it("shows concrete thinking without a model override in a tool call", () => {
     renderAgentToolCall({ agent: "agent", thinking: "high" }, noopTheme);
 
-    expect(textInstances.at(-1)?.text).toBe("▸ Agent (thinking: high)");
+    expect(textInstances.at(-1)?.text).toBe("▸ Agent (high)");
   });
 
   it("keeps the normal tool call unchanged without a concrete thinking level", () => {
@@ -91,7 +91,7 @@ describe("renderer", () => {
       details: { type: "builder", description: "Build something", modelName: "sonnet", thinkingLevel: "high", turnCount: 5 },
     }, { expanded: false }, noopTheme, SHOW_COST);
 
-    expect(textInstances.map((t) => t.text).join("\n")).toContain("Builder (sonnet · thinking: high)");
+    expect(textInstances.map((t) => t.text).join("\n")).toContain("Builder (sonnet · high)");
   });
 
   it("shows concrete thinking without inventing a model in a foreground result card", () => {
@@ -101,7 +101,7 @@ describe("renderer", () => {
     }, { expanded: false }, noopTheme, SHOW_COST);
 
     const text = textInstances.map((t) => t.text).join("\n");
-    expect(text).toContain("Builder (thinking: high)");
+    expect(text).toContain("Builder (high)");
     expect(text).not.toContain("undefined");
   });
 
@@ -138,7 +138,7 @@ describe("renderer", () => {
 
     renderSubagentResult(message, { expanded: false }, noopTheme, SHOW_COST);
 
-    expect(textInstances.map((t) => t.text).join("\n")).toContain("Builder (sonnet · thinking: high)");
+    expect(textInstances.map((t) => t.text).join("\n")).toContain("Builder (sonnet · high)");
   });
 
   it("shows concrete thinking without inventing a model in a background result card", () => {
@@ -148,7 +148,7 @@ describe("renderer", () => {
     }, { expanded: false }, noopTheme, SHOW_COST);
 
     const text = textInstances.map((t) => t.text).join("\n");
-    expect(text).toContain("Builder (thinking: high)");
+    expect(text).toContain("Builder (high)");
     expect(text).not.toContain("undefined");
   });
 

--- a/test/ui/renderer.test.ts
+++ b/test/ui/renderer.test.ts
@@ -37,8 +37,8 @@ vi.mock("@earendil-works/pi-tui", () => ({
 }));
 
 vi.mock("../../src/ui/format.js", () => ({
-  buildStatsParts: vi.fn(() => ["5 uses", "3 turns"]),
-  formatMs: vi.fn(() => "1m0s"),
+  buildStatsCells: vi.fn(() => ({ tools: "5⚙︎", turns: "3⟳", duration: "1m 0s" })),
+  formatStatsRow: vi.fn(() => "5⚙︎  3⟳ · 1m 0s"),
   formatThinkingTag: vi.fn((value: unknown) => value === "high" ? "high" : undefined),
   getDisplayName: vi.fn((type: string) => type.charAt(0).toUpperCase() + type.slice(1)),
 }));

--- a/test/ui/renderer.test.ts
+++ b/test/ui/renderer.test.ts
@@ -40,6 +40,16 @@ vi.mock("../../src/ui/format.js", () => ({
   buildStatsCells: vi.fn(() => ({ tools: "5⚙︎", turns: "3⟳", duration: "1m 0s" })),
   formatStatsRow: vi.fn(() => "5⚙︎  3⟳ · 1m 0s"),
   formatThinkingTag: vi.fn((value: unknown) => value === "high" ? "high" : undefined),
+  getAgentStatusDisplay: vi.fn((status: string) => {
+    const displays: Record<string, { icon: string; color: string }> = {
+      completed: { icon: "✓", color: "success" },
+      turn_limited: { icon: "✓", color: "warning" },
+      stopped: { icon: "■", color: "dim" },
+      error: { icon: "✗", color: "error" },
+      aborted: { icon: "✗", color: "error" },
+    };
+    return displays[status] ?? displays.completed;
+  }),
   getDisplayName: vi.fn((type: string) => type.charAt(0).toUpperCase() + type.slice(1)),
 }));
 
@@ -150,6 +160,24 @@ describe("renderer", () => {
     const text = textInstances.map((t) => t.text).join("\n");
     expect(text).toContain("Builder (high)");
     expect(text).not.toContain("undefined");
+  });
+
+  it.each([
+    ["stopped", "■", "dim"],
+    ["turn_limited", "✓", "warning"],
+  ])("uses the shared %s status icon and theme color", (status, icon, color) => {
+    const theme = {
+      ...noopTheme,
+      fg: vi.fn((themeColor: string, value: string) => `[${themeColor}]${value}`),
+    };
+
+    renderSubagentResult({
+      content: "Agent output",
+      details: { type: "builder", description: "Build something", turnCount: 5, status },
+    }, { expanded: false }, theme, SHOW_COST);
+
+    expect(textInstances.map((t) => t.text).join("\n")).toContain(`[${color}]${icon}`);
+    expect(theme.fg).toHaveBeenCalledWith(color, icon);
   });
 
   it("shows worktree path in fallback result line (no turnCount)", () => {

--- a/test/ui/worktree-widget-display.test.ts
+++ b/test/ui/worktree-widget-display.test.ts
@@ -38,12 +38,13 @@ vi.mock("@earendil-works/pi-tui", () => ({
 /*  Factories                                                         */
 /* ------------------------------------------------------------------ */
 
-function makeMockManager(agents: any[], totalAgentCost = 0): AgentManager {
+function makeMockManager(agents: any[], totalAgentCost = 0, totalAgentCount = agents.length): AgentManager {
   return {
     listAgents: () => agents,
     getAgent: () => undefined,
     setConcurrency: () => {},
     getTotalAgentCost: () => totalAgentCost,
+    getTotalAgentCount: () => totalAgentCount,
   } as any as AgentManager;
 }
 

--- a/test/ui/worktree-widget-display.test.ts
+++ b/test/ui/worktree-widget-display.test.ts
@@ -31,6 +31,7 @@ vi.mock("../../src/agents/agent-types.js", () => ({
 
 vi.mock("@earendil-works/pi-tui", () => ({
   truncateToWidth: (text: string, width: number) => text,
+  visibleWidth: (text: string) => text.length,
 }));
 
 /* ------------------------------------------------------------------ */

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { writeFileSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
 import { isUnsafeName, isSymlink, safeReadFile } from "../src/utils.ts";
-import { tempDirFixture } from "./fixtures";
+import { canCreateSymlinks, tempDirFixture } from "./fixtures";
+
+const itWithSymlinkSupport = it.skipIf(!canCreateSymlinks());
 
 /* ------------------------------------------------------------------ */
 /*  isUnsafeName                                                      */
@@ -69,7 +71,7 @@ describe("isSymlink", () => {
     expect(isSymlink(file)).toBe(false);
   });
 
-  it("returns true for a symlink", () => {
+  itWithSymlinkSupport("returns true for a symlink", () => {
     const target = join(getDir(), "target.txt");
     writeFileSync(target, "target content", "utf-8");
     const link = join(getDir(), "link.txt");
@@ -102,7 +104,7 @@ describe("safeReadFile", () => {
     expect(safeReadFile(file)).toBe("file content");
   });
 
-  it("returns undefined for a symlink", () => {
+  itWithSymlinkSupport("returns undefined for a symlink", () => {
     const target = join(getDir(), "target.txt");
     writeFileSync(target, "secret", "utf-8");
     const link = join(getDir(), "link.txt");


### PR DESCRIPTION
## Summary

This branch redesigns the agent status displays and aligns metadata and usage information across the live widget, conversation viewer, tool results, and background notifications.

### Highlights

- Adds optional, aligned model and thinking-level metadata, plus configurable local agent start times (`HH:MM`).
- Displays running, queued, and finished agents in one newest-first chronological list; queued agents now receive individual rows.
- Unifies lifecycle icons and colors across views (`◇` queued, `✓` completed, `■` stopped, `✗` failed/aborted).
- Aligns statistics with Pi's footer format: tool/turn counters, input/output tokens, cache reads/writes, latest cache hit rate, cost/subscription state, context usage/window, auto-compaction state, and duration.
- Persists final context, subscription, and usage snapshots after sessions finish.
- Includes compaction and tool-result usage in accounting without affecting assistant-only input-delta and cache-hit calculations.
- Improves widget column alignment, overflow prioritization, chronological navigation, and selected-row visibility.
- Keeps a session-level status summary after completed rows are evicted, e.g. `2 active · 7 agents total: $0.124`.
- Applies widget statistics visibility settings to the conversation viewer as well.
- Adds settings for model/thinking display and local start times; makes compact-mode shortcut synchronization immediate.
- Treats widget line limits as total lines including the heading, with a minimum of two lines.
- Changes the default thinking-output buffer to OFF and updates the README configuration reference.

## Updated displays

### Live widget

```text
◈ Agents
  ⠙ 09:42 Agent    (claude-sonnet-4 · high) Write model precedence tests  6⚙︎  3⟳ · ↑6.8k ↓1.3k R42k CH86.2% $0.024 6.0%/128k (auto) · 12s
  │ tail -f /tmp/pi-agent-outputs/bb3382a9.log
  └ Running unit tests…
  ◇ 09:41 Reviewer (gpt-5 · medium)          Review agent-runner.ts
  ✓ 09:40 Explore  (gemini-2.5-pro · high)   Explore project architecture   13⚙︎  4⟳ · ↑16k ↓2.9k 15.0%/128k (auto) · 21s
```

### Result card

```text
✓ Explore (gemini-2.5-pro · high) · 13⚙︎  5⟳ · ↑25.9k ↓4.9k R85k W3.0k CH89.2% $0.024 · 21s
  Explore project architecture
```

### Conversation viewer statistics

```text
15⚙︎  6⟳ · ↑12k ↓8.0k R85k W3.0k CH89.2% $0.024 47.0%/128k (auto) · 47s
```

## Validation

- `bun run typecheck`
- `bun run test` — 47 test files passed, 1030 tests passed, 3 skipped

