### PR TITLE
Hide background completions when compact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Optional compact completion hiding.** Widget Behavior settings can hide background-agent completion cards while tool output is collapsed; results remain available to the model and Running agents.
+- **Optional background completion hiding.** Widget Behavior settings can hide background-agent completion cards from the TUI; results remain available to the model and Running agents.
 
 ## [1.7.0] - 2026-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Optional compact completion hiding.** Widget Behavior settings can hide background-agent completion cards while tool output is collapsed; results remain available to the model and Running agents.
+
 ## [1.7.0] - 2026-08-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ When `includeContextFiles` is `true` (default), AGENTS.md files load as shared c
     "widgetMaxLinesCompact": 6,
     "widgetDescLengthFull": 50,
     "widgetCompact": true,
-    "hideBackgroundCompletionsWhenCompact": false,
+    "hideBackgroundCompletions": false,
     "widgetShortcut": false,
     "systemPromptMode": "inherit",
     "includeContextFiles": true,
@@ -156,7 +156,7 @@ When `includeContextFiles` is `true` (default), AGENTS.md files load as shared c
 }
 ```
 
-Widget, stats visibility, and spawn defaults are all under `/agents` > Settings. When `hideBackgroundCompletionsWhenCompact` is enabled under Widget settings → Behavior, background-agent completion cards are hidden whenever tool output is collapsed. Their results remain available to the model and through Running agents.
+Widget, stats visibility, and spawn defaults are all under `/agents` > Settings. When `hideBackgroundCompletions` is enabled under Widget settings → Behavior, background-agent completion cards are hidden from the TUI. Their results remain available to the model and through Running agents.
 
 Output logs land in `/tmp/pi-agent-outputs/<agentId>.log`, append-only and `tail -f` friendly. Logs and completed results survive on disk even if a session reload (`/reload`, extension reload) kills running agents.
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ When `includeContextFiles` is `true` (default), AGENTS.md files load as shared c
     "widgetMaxLinesCompact": 6,
     "widgetDescLengthFull": 50,
     "widgetCompact": true,
-    "hideBackgroundCompletions": false,
+    "showCompletionCards": true,
     "widgetShortcut": false,
     "systemPromptMode": "inherit",
     "includeContextFiles": true,

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ When `includeContextFiles` is `true` (default), AGENTS.md files load as shared c
 }
 ```
 
-Widget, stats visibility, and spawn defaults are all under `/agents` > Settings. When `hideBackgroundCompletions` is enabled under Widget settings → Behavior, background-agent completion cards are hidden from the TUI. Their results remain available to the model and through Running agents.
+Widget, stats visibility, and spawn defaults are all under `/agents` > Settings.
 
 Output logs land in `/tmp/pi-agent-outputs/<agentId>.log`, append-only and `tail -f` friendly. Logs and completed results survive on disk even if a session reload (`/reload`, extension reload) kills running agents.
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ When `includeContextFiles` is `true` (default), AGENTS.md files load as shared c
     "widgetMaxLinesCompact": 6,
     "widgetDescLengthFull": 50,
     "widgetCompact": true,
+    "hideBackgroundCompletionsWhenCompact": false,
     "widgetShortcut": false,
     "systemPromptMode": "inherit",
     "includeContextFiles": true,
@@ -155,7 +156,7 @@ When `includeContextFiles` is `true` (default), AGENTS.md files load as shared c
 }
 ```
 
-Widget, stats visibility, and spawn defaults are all under `/agents` > Settings.
+Widget, stats visibility, and spawn defaults are all under `/agents` > Settings. When `hideBackgroundCompletionsWhenCompact` is enabled under Widget settings → Behavior, background-agent completion cards are hidden whenever tool output is collapsed. Their results remain available to the model and through Running agents.
 
 Output logs land in `/tmp/pi-agent-outputs/<agentId>.log`, append-only and `tail -f` friendly. Logs and completed results survive on disk even if a session reload (`/reload`, extension reload) kills running agents.
 

--- a/src/config/config-io.ts
+++ b/src/config/config-io.ts
@@ -36,6 +36,7 @@ const DEFAULT_AGENT: SubagentsConfig["agent"] = {
   widgetDescLengthFull: 50,
   widgetDescLengthCompact: 30,
   widgetCompact: false,
+  hideBackgroundCompletionsWhenCompact: false,
   widgetShortcut: false,
   widgetShowModel: true,
   widgetShowThinking: true,

--- a/src/config/config-io.ts
+++ b/src/config/config-io.ts
@@ -36,7 +36,7 @@ const DEFAULT_AGENT: SubagentsConfig["agent"] = {
   widgetDescLengthFull: 50,
   widgetDescLengthCompact: 30,
   widgetCompact: false,
-  hideBackgroundCompletionsWhenCompact: false,
+  hideBackgroundCompletions: false,
   widgetShortcut: false,
   widgetShowModel: true,
   widgetShowThinking: true,

--- a/src/config/config-io.ts
+++ b/src/config/config-io.ts
@@ -36,7 +36,7 @@ export const DEFAULT_AGENT: SubagentsConfig["agent"] = {
   widgetDescLengthFull: 50,
   widgetDescLengthCompact: 30,
   widgetCompact: false,
-  hideBackgroundCompletions: false,
+  showCompletionCards: true,
   widgetShortcut: false,
   widgetShowModel: true,
   widgetShowThinking: true,

--- a/src/config/config-store.ts
+++ b/src/config/config-store.ts
@@ -50,7 +50,7 @@ export interface ResolvedAgentSettings {
   readonly widgetMaxLines: number;
   readonly widgetMaxLinesCompact: number;
   readonly widgetCompact: boolean;
-  readonly hideBackgroundCompletions: boolean;
+  readonly showCompletionCards: boolean;
   readonly widgetShortcut: boolean;
   readonly widgetShowModel: boolean;
   readonly widgetShowThinking: boolean;
@@ -142,7 +142,7 @@ export class ConfigStore {
       widgetMaxLines,
       widgetMaxLinesCompact,
       widgetCompact: a.widgetCompact === true,
-      hideBackgroundCompletions: a.hideBackgroundCompletions === true,
+      showCompletionCards: a.showCompletionCards !== false,
       widgetShortcut: a.widgetShortcut === true,
       widgetShowModel: a.widgetShowModel !== false,
       widgetShowThinking: a.widgetShowThinking !== false,
@@ -342,8 +342,8 @@ export class ConfigStore {
         this.persist();
         this.syncWidgetSettings();
       },
-      setHideBackgroundCompletions: (enabled: boolean): void => {
-        this.config.agent.hideBackgroundCompletions = enabled;
+      setShowCompletionCards: (enabled: boolean): void => {
+        this.config.agent.showCompletionCards = enabled;
         this.persist();
       },
       setMaxLines: (lines: number): void => {

--- a/src/config/config-store.ts
+++ b/src/config/config-store.ts
@@ -50,7 +50,6 @@ export interface ResolvedAgentSettings {
   readonly widgetMaxLines: number;
   readonly widgetMaxLinesCompact: number;
   readonly widgetCompact: boolean;
-  /** Hide background completion cards from the TUI. */
   readonly hideBackgroundCompletions: boolean;
   readonly widgetShortcut: boolean;
   readonly widgetShowModel: boolean;

--- a/src/config/config-store.ts
+++ b/src/config/config-store.ts
@@ -50,8 +50,8 @@ export interface ResolvedAgentSettings {
   readonly widgetMaxLines: number;
   readonly widgetMaxLinesCompact: number;
   readonly widgetCompact: boolean;
-  /** Hide background completion cards whenever custom message output is not expanded. */
-  readonly hideBackgroundCompletionsWhenCompact: boolean;
+  /** Hide background completion cards from the TUI. */
+  readonly hideBackgroundCompletions: boolean;
   readonly widgetShortcut: boolean;
   readonly widgetShowModel: boolean;
   readonly widgetShowThinking: boolean;
@@ -143,7 +143,7 @@ export class ConfigStore {
       widgetMaxLines,
       widgetMaxLinesCompact,
       widgetCompact: a.widgetCompact === true,
-      hideBackgroundCompletionsWhenCompact: a.hideBackgroundCompletionsWhenCompact === true,
+      hideBackgroundCompletions: a.hideBackgroundCompletions === true,
       widgetShortcut: a.widgetShortcut === true,
       widgetShowModel: a.widgetShowModel !== false,
       widgetShowThinking: a.widgetShowThinking !== false,
@@ -343,8 +343,8 @@ export class ConfigStore {
         this.persist();
         this.syncWidgetSettings();
       },
-      setHideBackgroundCompletionsWhenCompact: (enabled: boolean): void => {
-        this.config.agent.hideBackgroundCompletionsWhenCompact = enabled;
+      setHideBackgroundCompletions: (enabled: boolean): void => {
+        this.config.agent.hideBackgroundCompletions = enabled;
         this.persist();
       },
       setMaxLines: (lines: number): void => {

--- a/src/config/config-store.ts
+++ b/src/config/config-store.ts
@@ -50,6 +50,8 @@ export interface ResolvedAgentSettings {
   readonly widgetMaxLines: number;
   readonly widgetMaxLinesCompact: number;
   readonly widgetCompact: boolean;
+  /** Hide background completion cards whenever custom message output is not expanded. */
+  readonly hideBackgroundCompletionsWhenCompact: boolean;
   readonly widgetShortcut: boolean;
   readonly widgetShowModel: boolean;
   readonly widgetShowThinking: boolean;
@@ -141,6 +143,7 @@ export class ConfigStore {
       widgetMaxLines,
       widgetMaxLinesCompact,
       widgetCompact: a.widgetCompact === true,
+      hideBackgroundCompletionsWhenCompact: a.hideBackgroundCompletionsWhenCompact === true,
       widgetShortcut: a.widgetShortcut === true,
       widgetShowModel: a.widgetShowModel !== false,
       widgetShowThinking: a.widgetShowThinking !== false,
@@ -339,6 +342,10 @@ export class ConfigStore {
         this.config.agent.widgetCompact = enabled;
         this.persist();
         this.syncWidgetSettings();
+      },
+      setHideBackgroundCompletionsWhenCompact: (enabled: boolean): void => {
+        this.config.agent.hideBackgroundCompletionsWhenCompact = enabled;
+        this.persist();
       },
       setMaxLines: (lines: number): void => {
         this.config.agent.widgetMaxLines = lines;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -18,6 +18,7 @@ export const CONFIG_AGENT_NON_MODEL_KEYS = [
   "widgetDescLengthFull",
   "widgetDescLengthCompact",
   "widgetCompact",
+  "hideBackgroundCompletionsWhenCompact",
   "widgetShortcut",
   "widgetShowModel",
   "widgetShowThinking",

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -18,7 +18,7 @@ export const CONFIG_AGENT_NON_MODEL_KEYS = [
   "widgetDescLengthFull",
   "widgetDescLengthCompact",
   "widgetCompact",
-  "hideBackgroundCompletionsWhenCompact",
+  "hideBackgroundCompletions",
   "widgetShortcut",
   "widgetShowModel",
   "widgetShowThinking",

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -18,7 +18,7 @@ export const CONFIG_AGENT_NON_MODEL_KEYS = [
   "widgetDescLengthFull",
   "widgetDescLengthCompact",
   "widgetCompact",
-  "hideBackgroundCompletions",
+  "showCompletionCards",
   "widgetShortcut",
   "widgetShowModel",
   "widgetShowThinking",

--- a/src/models/model-precedence.ts
+++ b/src/models/model-precedence.ts
@@ -29,8 +29,8 @@ export interface SubagentsConfig {
     widgetMaxLines?: number;
     widgetMaxLinesCompact?: number;
     widgetCompact?: boolean;
-    /** Hide background completion cards from the TUI. Default: false. */
-    hideBackgroundCompletions?: boolean;
+    /** Show background completion cards in the TUI. Default: true. */
+    showCompletionCards?: boolean;
     widgetShortcut?: boolean;
     /** System prompt mode: replace (default), inherit parent, or custom file. */
     systemPromptMode?: SystemPromptMode;

--- a/src/models/model-precedence.ts
+++ b/src/models/model-precedence.ts
@@ -29,6 +29,8 @@ export interface SubagentsConfig {
     widgetMaxLines?: number;
     widgetMaxLinesCompact?: number;
     widgetCompact?: boolean;
+    /** Hide background completion cards while custom message tool output is collapsed. Default: false. */
+    hideBackgroundCompletionsWhenCompact?: boolean;
     widgetShortcut?: boolean;
     /** System prompt mode: replace (default), inherit parent, or custom file. */
     systemPromptMode?: SystemPromptMode;

--- a/src/models/model-precedence.ts
+++ b/src/models/model-precedence.ts
@@ -29,8 +29,8 @@ export interface SubagentsConfig {
     widgetMaxLines?: number;
     widgetMaxLinesCompact?: number;
     widgetCompact?: boolean;
-    /** Hide background completion cards while custom message tool output is collapsed. Default: false. */
-    hideBackgroundCompletionsWhenCompact?: boolean;
+    /** Hide background completion cards from the TUI. Default: false. */
+    hideBackgroundCompletions?: boolean;
     widgetShortcut?: boolean;
     /** System prompt mode: replace (default), inherit parent, or custom file. */
     systemPromptMode?: SystemPromptMode;

--- a/src/models/model-precedence.ts
+++ b/src/models/model-precedence.ts
@@ -29,7 +29,7 @@ export interface SubagentsConfig {
     widgetMaxLines?: number;
     widgetMaxLinesCompact?: number;
     widgetCompact?: boolean;
-    /** Hide background completion cards from the TUI. Default: false. */
+    /** Hide background completion cards from the TUI. Applies from the next completion. Default: false. */
     hideBackgroundCompletions?: boolean;
     widgetShortcut?: boolean;
     /** System prompt mode: replace (default), inherit parent, or custom file. */

--- a/src/models/model-precedence.ts
+++ b/src/models/model-precedence.ts
@@ -29,7 +29,7 @@ export interface SubagentsConfig {
     widgetMaxLines?: number;
     widgetMaxLinesCompact?: number;
     widgetCompact?: boolean;
-    /** Hide background completion cards from the TUI. Applies from the next completion. Default: false. */
+    /** Hide background completion cards from the TUI. Default: false. */
     hideBackgroundCompletions?: boolean;
     widgetShortcut?: boolean;
     /** System prompt mode: replace (default), inherit parent, or custom file. */

--- a/src/registration.ts
+++ b/src/registration.ts
@@ -117,7 +117,7 @@ export function registerTools(pi: ExtensionAPI): void {
       theme,
       store.agent.showCost,
       store.agent.modelDisplayStyle,
-      store.agent.hideBackgroundCompletions,
+      !store.agent.showCompletionCards,
     );
   });
 

--- a/src/registration.ts
+++ b/src/registration.ts
@@ -117,7 +117,7 @@ export function registerTools(pi: ExtensionAPI): void {
       theme,
       store.agent.showCost,
       store.agent.modelDisplayStyle,
-      store.agent.hideBackgroundCompletionsWhenCompact,
+      store.agent.hideBackgroundCompletions,
     );
   });
 

--- a/src/registration.ts
+++ b/src/registration.ts
@@ -117,6 +117,7 @@ export function registerTools(pi: ExtensionAPI): void {
       theme,
       store.agent.showCost,
       store.agent.modelDisplayStyle,
+      store.agent.hideBackgroundCompletionsWhenCompact,
     );
   });
 

--- a/src/ui/menu/menu-widget-settings.ts
+++ b/src/ui/menu/menu-widget-settings.ts
@@ -170,7 +170,7 @@ function buildBehaviorItems(ctx: ExtensionCommandContext, store: ReturnType<type
       label: "Hide background completions",
       currentValue: store.agent.hideBackgroundCompletions ? "ON" : "OFF",
       values: ["ON", "OFF"],
-      description: "Hide background-agent completion cards. Results remain available to the model and Running agents.",
+      description: "Hide background-agent completion cards; applies from the next completion.",
     },
     {
       id: "thinkingBuffer",

--- a/src/ui/menu/menu-widget-settings.ts
+++ b/src/ui/menu/menu-widget-settings.ts
@@ -165,6 +165,14 @@ function buildBehaviorItems(ctx: ExtensionCommandContext, store: ReturnType<type
       description: "When ON, ctrl+o toggles compact mode; when OFF, compact is set manually.",
     },
     {
+      id: "hideBackgroundCompletionsWhenCompact",
+      label: "Hide background completions when compact",
+      currentValue: store.agent.hideBackgroundCompletionsWhenCompact ? "ON" : "OFF",
+      values: ["ON", "OFF"],
+      description:
+        "Hide background-agent completion cards while tool output is collapsed. Results remain available to the model and Running agents.",
+    },
+    {
       id: "thinkingBuffer",
       label: "Log file thinking buffer",
       currentValue: store.agent.outputThinkingBufferSize === 0 ? "OFF" : String(store.agent.outputThinkingBufferSize),
@@ -266,6 +274,10 @@ function buildOnChange(ctx: ExtensionCommandContext, store: ReturnType<typeof ge
         store.mutate.widget.setShortcut(newValue === "ON");
         ctx.ui.notify(`Ctrl+o shortcut ${newValue}`, "info");
         break;
+      case "hideBackgroundCompletionsWhenCompact":
+        store.mutate.widget.setHideBackgroundCompletionsWhenCompact(newValue === "ON");
+        ctx.ui.notify(`Hide background completions when compact ${newValue}`, "info");
+        break;
       case "thinkingBuffer":
         store.mutate.agent.setOutputThinkingBufferSize(newValue === "OFF" ? 0 : Number(newValue));
         ctx.ui.notify(`Thinking buffer ${newValue}`, "info");
@@ -300,7 +312,11 @@ export async function showWidgetSettingsMenu(ctx: ExtensionCommandContext): Prom
   const items: SelectItem[] = [
     { value: "layout", label: "Layout", description: "Compact mode, max lines, description length" },
     { value: "display", label: "Display", description: "Status bar, model/thinking visibility, navigation hint" },
-    { value: "behavior", label: "Behavior", description: "Shortcuts, thinking buffer, finished agent retention" },
+    {
+      value: "behavior",
+      label: "Behavior",
+      description: "Shortcuts, completion cards, thinking buffer, finished agent retention",
+    },
     { value: "stats", label: "Stats", description: "Toggle which usage stats appear in the widget" },
   ];
 

--- a/src/ui/menu/menu-widget-settings.ts
+++ b/src/ui/menu/menu-widget-settings.ts
@@ -170,7 +170,7 @@ function buildBehaviorItems(ctx: ExtensionCommandContext, store: ReturnType<type
       label: "Hide background completions",
       currentValue: store.agent.hideBackgroundCompletions ? "ON" : "OFF",
       values: ["ON", "OFF"],
-      description: "Hide background-agent completion cards; applies from the next completion.",
+      description: "Hide background-agent completion cards.",
     },
     {
       id: "thinkingBuffer",
@@ -276,6 +276,7 @@ function buildOnChange(ctx: ExtensionCommandContext, store: ReturnType<typeof ge
         break;
       case "hideBackgroundCompletions":
         store.mutate.widget.setHideBackgroundCompletions(newValue === "ON");
+        refreshChatComponents(ctx);
         ctx.ui.notify(`Hide background completions ${newValue}`, "info");
         break;
       case "thinkingBuffer":
@@ -288,6 +289,19 @@ function buildOnChange(ctx: ExtensionCommandContext, store: ReturnType<typeof ge
         break;
     }
   };
+}
+
+/**
+ * Rebuild cached chat cards via the only host lever: flipping the tool-output
+ * expansion state triggers setExpanded on every expandable chat component, which
+ * re-runs the message renderer (its result is otherwise cached). The double flip
+ * restores the original state. No-op on hosts without the expansion API.
+ */
+function refreshChatComponents(ctx: ExtensionCommandContext): void {
+  if (typeof ctx.ui.getToolsExpanded !== "function" || typeof ctx.ui.setToolsExpanded !== "function") return;
+  const expanded = ctx.ui.getToolsExpanded();
+  ctx.ui.setToolsExpanded(!expanded);
+  ctx.ui.setToolsExpanded(expanded);
 }
 
 /** Show a SettingsList submenu for a specific category. */

--- a/src/ui/menu/menu-widget-settings.ts
+++ b/src/ui/menu/menu-widget-settings.ts
@@ -166,11 +166,11 @@ function buildBehaviorItems(ctx: ExtensionCommandContext, store: ReturnType<type
         "When ON, ctrl+o toggles compact mode; when OFF, compact is set manually. Takes effect on next reload.",
     },
     {
-      id: "hideBackgroundCompletions",
-      label: "Hide background completions",
-      currentValue: store.agent.hideBackgroundCompletions ? "ON" : "OFF",
+      id: "showCompletionCards",
+      label: "Show completion cards",
+      currentValue: store.agent.showCompletionCards ? "ON" : "OFF",
       values: ["ON", "OFF"],
-      description: "Hide background-agent completion cards.",
+      description: "Show background-agent completion cards in the transcript; turn OFF to hide them.",
     },
     {
       id: "thinkingBuffer",
@@ -274,10 +274,10 @@ function buildOnChange(ctx: ExtensionCommandContext, store: ReturnType<typeof ge
         store.mutate.widget.setShortcut(newValue === "ON");
         ctx.ui.notify(`Ctrl+o shortcut ${newValue}`, "info");
         break;
-      case "hideBackgroundCompletions":
-        store.mutate.widget.setHideBackgroundCompletions(newValue === "ON");
+      case "showCompletionCards":
+        store.mutate.widget.setShowCompletionCards(newValue === "ON");
         refreshChatComponents(ctx);
-        ctx.ui.notify(`Hide background completions ${newValue}`, "info");
+        ctx.ui.notify(`Show completion cards ${newValue}`, "info");
         break;
       case "thinkingBuffer":
         store.mutate.agent.setOutputThinkingBufferSize(newValue === "OFF" ? 0 : Number(newValue));

--- a/src/ui/menu/menu-widget-settings.ts
+++ b/src/ui/menu/menu-widget-settings.ts
@@ -165,12 +165,11 @@ function buildBehaviorItems(ctx: ExtensionCommandContext, store: ReturnType<type
       description: "When ON, ctrl+o toggles compact mode; when OFF, compact is set manually.",
     },
     {
-      id: "hideBackgroundCompletionsWhenCompact",
-      label: "Hide background completions when compact",
-      currentValue: store.agent.hideBackgroundCompletionsWhenCompact ? "ON" : "OFF",
+      id: "hideBackgroundCompletions",
+      label: "Hide background completions",
+      currentValue: store.agent.hideBackgroundCompletions ? "ON" : "OFF",
       values: ["ON", "OFF"],
-      description:
-        "Hide background-agent completion cards while tool output is collapsed. Results remain available to the model and Running agents.",
+      description: "Hide background-agent completion cards. Results remain available to the model and Running agents.",
     },
     {
       id: "thinkingBuffer",
@@ -274,9 +273,9 @@ function buildOnChange(ctx: ExtensionCommandContext, store: ReturnType<typeof ge
         store.mutate.widget.setShortcut(newValue === "ON");
         ctx.ui.notify(`Ctrl+o shortcut ${newValue}`, "info");
         break;
-      case "hideBackgroundCompletionsWhenCompact":
-        store.mutate.widget.setHideBackgroundCompletionsWhenCompact(newValue === "ON");
-        ctx.ui.notify(`Hide background completions when compact ${newValue}`, "info");
+      case "hideBackgroundCompletions":
+        store.mutate.widget.setHideBackgroundCompletions(newValue === "ON");
+        ctx.ui.notify(`Hide background completions ${newValue}`, "info");
         break;
       case "thinkingBuffer":
         store.mutate.agent.setOutputThinkingBufferSize(newValue === "OFF" ? 0 : Number(newValue));

--- a/src/ui/renderer.ts
+++ b/src/ui/renderer.ts
@@ -116,10 +116,10 @@ export function renderSubagentResult(
   theme: Theme,
   showCost: boolean,
   modelDisplayStyle: "id" | "name" = "id",
-  hideWhenCollapsed = false,
+  hide = false,
 ): Container {
   const { expanded } = options;
-  if (hideWhenCollapsed && expanded !== true) return new Container();
+  if (hide) return new Container();
 
   const d = message.details;
   const text = (message.content as string)?.trim() || "";

--- a/src/ui/renderer.ts
+++ b/src/ui/renderer.ts
@@ -116,8 +116,11 @@ export function renderSubagentResult(
   theme: Theme,
   showCost: boolean,
   modelDisplayStyle: "id" | "name" = "id",
+  hideWhenCollapsed = false,
 ): Container {
   const { expanded } = options;
+  if (hideWhenCollapsed && expanded !== true) return new Container();
+
   const d = message.details;
   const text = (message.content as string)?.trim() || "";
 

--- a/test/config/config-store.test.ts
+++ b/test/config/config-store.test.ts
@@ -22,7 +22,7 @@ function defaultConfig(): SubagentsConfig {
       widgetDescLengthFull: 50,
       widgetDescLengthCompact: 30,
       widgetCompact: false,
-      hideBackgroundCompletionsWhenCompact: false,
+      hideBackgroundCompletions: false,
       widgetShortcut: false,
       systemPromptMode: "replace",
       includeContextFiles: true,
@@ -111,7 +111,7 @@ describe("ConfigStore reads", () => {
     expect(store.agent.widgetMaxLines).toBe(12);
     expect(store.agent.widgetMaxLinesCompact).toBe(6);
     expect(store.agent.widgetCompact).toBe(false);
-    expect(store.agent.hideBackgroundCompletionsWhenCompact).toBe(false);
+    expect(store.agent.hideBackgroundCompletions).toBe(false);
     expect(store.agent.widgetShortcut).toBe(false);
     expect(store.agent.defaultModel).toBeNull();
     expect(store.agent.finishedRetentionMinutes).toBe(10);
@@ -244,14 +244,14 @@ describe("ConfigStore persisted mutations", () => {
     expect(calls).toContain("setForceCompact:true");
   });
 
-  it("setHideBackgroundCompletionsWhenCompact persists", () => {
+  it("setHideBackgroundCompletions persists", () => {
     const { io, saves } = memIO();
     const store = new ConfigStore(io);
 
-    store.mutate.widget.setHideBackgroundCompletionsWhenCompact(true);
+    store.mutate.widget.setHideBackgroundCompletions(true);
 
-    expect(store.agent.hideBackgroundCompletionsWhenCompact).toBe(true);
-    expect(saves[0].agent.hideBackgroundCompletionsWhenCompact).toBe(true);
+    expect(store.agent.hideBackgroundCompletions).toBe(true);
+    expect(saves[0].agent.hideBackgroundCompletions).toBe(true);
   });
 
   it("setShortcut persists but does not sync widget", () => {
@@ -385,7 +385,7 @@ describe("ConfigStore model-override clearing", () => {
         graceTurns: 7,
         showCost: true,
         widgetMaxLines: 14,
-        hideBackgroundCompletionsWhenCompact: true,
+        hideBackgroundCompletions: true,
         Explore: "m1",
         general: "m2",
       },
@@ -401,7 +401,7 @@ describe("ConfigStore model-override clearing", () => {
     expect(snap.graceTurns).toBe(7);
     expect(snap.showCost).toBe(true);
     expect(snap.widgetMaxLines).toBe(14);
-    expect(snap.hideBackgroundCompletionsWhenCompact).toBe(true);
+    expect(snap.hideBackgroundCompletions).toBe(true);
   });
 });
 

--- a/test/config/config-store.test.ts
+++ b/test/config/config-store.test.ts
@@ -22,7 +22,7 @@ function defaultConfig(): SubagentsConfig {
       widgetDescLengthFull: 50,
       widgetDescLengthCompact: 30,
       widgetCompact: false,
-      hideBackgroundCompletions: false,
+      showCompletionCards: true,
       widgetShortcut: false,
       systemPromptMode: "replace",
       includeContextFiles: true,
@@ -125,7 +125,7 @@ describe("ConfigStore reads", () => {
     expect(store.agent.showCost).toBe(false);
     expect(store.agent.forceBackground).toBe(false);
     expect(store.agent.widgetCompact).toBe(false);
-    expect(store.agent.hideBackgroundCompletions).toBe(false);
+    expect(store.agent.showCompletionCards).toBe(true);
     expect(store.agent.widgetShortcut).toBe(false);
     expect(store.agent.defaultModel).toBeNull();
     expect(store.agent.finishedRetentionMinutes).toBe(10);
@@ -272,14 +272,14 @@ describe("ConfigStore persisted mutations", () => {
     expect(calls).toContain("setForceCompact:true");
   });
 
-  it("setHideBackgroundCompletions persists", () => {
+  it("setShowCompletionCards persists", () => {
     const { io, saves } = memIO();
     const store = new ConfigStore(io);
 
-    store.mutate.widget.setHideBackgroundCompletions(true);
+    store.mutate.widget.setShowCompletionCards(false);
 
-    expect(store.agent.hideBackgroundCompletions).toBe(true);
-    expect(saves[0].agent.hideBackgroundCompletions).toBe(true);
+    expect(store.agent.showCompletionCards).toBe(false);
+    expect(saves[0].agent.showCompletionCards).toBe(false);
   });
 
   it("setShortcut persists but does not sync widget", () => {
@@ -413,7 +413,7 @@ describe("ConfigStore model-override clearing", () => {
         graceTurns: 7,
         showCost: true,
         widgetMaxLines: 14,
-        hideBackgroundCompletions: true,
+        showCompletionCards: true,
         Explore: "m1",
         general: "m2",
       },
@@ -429,7 +429,7 @@ describe("ConfigStore model-override clearing", () => {
     expect(snap.graceTurns).toBe(7);
     expect(snap.showCost).toBe(true);
     expect(snap.widgetMaxLines).toBe(14);
-    expect(snap.hideBackgroundCompletions).toBe(true);
+    expect(snap.showCompletionCards).toBe(true);
   });
 });
 

--- a/test/config/config-store.test.ts
+++ b/test/config/config-store.test.ts
@@ -22,6 +22,7 @@ function defaultConfig(): SubagentsConfig {
       widgetDescLengthFull: 50,
       widgetDescLengthCompact: 30,
       widgetCompact: false,
+      hideBackgroundCompletionsWhenCompact: false,
       widgetShortcut: false,
       systemPromptMode: "replace",
       includeContextFiles: true,
@@ -110,6 +111,7 @@ describe("ConfigStore reads", () => {
     expect(store.agent.widgetMaxLines).toBe(12);
     expect(store.agent.widgetMaxLinesCompact).toBe(6);
     expect(store.agent.widgetCompact).toBe(false);
+    expect(store.agent.hideBackgroundCompletionsWhenCompact).toBe(false);
     expect(store.agent.widgetShortcut).toBe(false);
     expect(store.agent.defaultModel).toBeNull();
     expect(store.agent.finishedRetentionMinutes).toBe(10);
@@ -240,6 +242,16 @@ describe("ConfigStore persisted mutations", () => {
     store.mutate.widget.setCompact(true);
     expect(store.agent.widgetCompact).toBe(true);
     expect(calls).toContain("setForceCompact:true");
+  });
+
+  it("setHideBackgroundCompletionsWhenCompact persists", () => {
+    const { io, saves } = memIO();
+    const store = new ConfigStore(io);
+
+    store.mutate.widget.setHideBackgroundCompletionsWhenCompact(true);
+
+    expect(store.agent.hideBackgroundCompletionsWhenCompact).toBe(true);
+    expect(saves[0].agent.hideBackgroundCompletionsWhenCompact).toBe(true);
   });
 
   it("setShortcut persists but does not sync widget", () => {
@@ -373,6 +385,7 @@ describe("ConfigStore model-override clearing", () => {
         graceTurns: 7,
         showCost: true,
         widgetMaxLines: 14,
+        hideBackgroundCompletionsWhenCompact: true,
         Explore: "m1",
         general: "m2",
       },
@@ -388,6 +401,7 @@ describe("ConfigStore model-override clearing", () => {
     expect(snap.graceTurns).toBe(7);
     expect(snap.showCost).toBe(true);
     expect(snap.widgetMaxLines).toBe(14);
+    expect(snap.hideBackgroundCompletionsWhenCompact).toBe(true);
   });
 });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -147,7 +147,7 @@ const { mutableStore, spawnGuard } = vi.hoisted(() => ({
       showCost: false,
       agentToolStrictMode: false,
       modelDisplayStyle: "id",
-      hideBackgroundCompletionsWhenCompact: false,
+      hideBackgroundCompletions: false,
     },
     modelFor: () => "anthropic/claude-sonnet-4-6",
   },
@@ -273,20 +273,20 @@ describe("message renderer registration", () => {
   });
 
   beforeEach(() => {
-    mutableStore.agent.hideBackgroundCompletionsWhenCompact = false;
+    mutableStore.agent.hideBackgroundCompletions = false;
   });
 
   it("registers the subagent-result renderer", () => {
     expect(api.messageRenderers.map((r) => r.customType)).toContain("subagent-result");
   });
 
-  it("uses the persisted setting and renderer expanded state", () => {
+  it("uses the persisted setting regardless of renderer expanded state", () => {
     const renderer = api.messageRenderers.find((r) => r.customType === "subagent-result")!.renderer;
     const theme = { fg: (_color: string, text: string) => text, bg: (_color: string, text: string) => text };
 
-    mutableStore.agent.hideBackgroundCompletionsWhenCompact = true;
+    mutableStore.agent.hideBackgroundCompletions = true;
     expect(renderer({ content: "done" }, { expanded: false }, theme).children).toHaveLength(0);
-    expect(renderer({ content: "done" }, { expanded: true }, theme).children.length).toBeGreaterThan(0);
+    expect(renderer({ content: "done" }, { expanded: true }, theme).children).toHaveLength(0);
   });
 });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -51,12 +51,7 @@ vi.mock("@earendil-works/pi-coding-agent", () => ({
 }));
 
 vi.mock("@earendil-works/pi-tui", () => ({
-  Box: class {
-    children: any[] = [];
-    addChild(c: any) {
-      this.children.push(c);
-    }
-  },
+  Box: class {},
   Container: class {
     children: any[] = [];
     addChild(c: any) {
@@ -146,7 +141,6 @@ const { mutableStore, spawnGuard } = vi.hoisted(() => ({
       forceBackground: false,
       showCost: false,
       agentToolStrictMode: false,
-      modelDisplayStyle: "id",
       hideBackgroundCompletions: false,
     },
     modelFor: () => "anthropic/claude-sonnet-4-6",
@@ -252,7 +246,7 @@ describe("Agent tool schema — stealth", () => {
 });
 
 /* ------------------------------------------------------------------ */
-/*  Tool Registration Count                                           */
+/*  Message Renderer Registration                                     */
 /* ------------------------------------------------------------------ */
 
 describe("message renderer registration", () => {
@@ -280,6 +274,10 @@ describe("message renderer registration", () => {
     expect(renderer({ content: "done" }, { expanded: true }, theme).children).toHaveLength(0);
   });
 });
+
+/* ------------------------------------------------------------------ */
+/*  Tool Registration Count                                           */
+/* ------------------------------------------------------------------ */
 
 describe("tool registration", () => {
   let api: MockExtensionAPI;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -51,7 +51,12 @@ vi.mock("@earendil-works/pi-coding-agent", () => ({
 }));
 
 vi.mock("@earendil-works/pi-tui", () => ({
-  Box: class {},
+  Box: class {
+    children: any[] = [];
+    addChild(c: any) {
+      this.children.push(c);
+    }
+  },
   Container: class {
     children: any[] = [];
     addChild(c: any) {
@@ -136,7 +141,14 @@ vi.mock("../src/ui/agent-widget.js", () => ({
 // Mutable state shared between the shell mock and tests.
 const { mutableStore, spawnGuard } = vi.hoisted(() => ({
   mutableStore: {
-    agent: { graceTurns: 6, forceBackground: false, showCost: false, agentToolStrictMode: false },
+    agent: {
+      graceTurns: 6,
+      forceBackground: false,
+      showCost: false,
+      agentToolStrictMode: false,
+      modelDisplayStyle: "id",
+      hideBackgroundCompletionsWhenCompact: false,
+    },
     modelFor: () => "anthropic/claude-sonnet-4-6",
   },
   spawnGuard: { depth: 0 },
@@ -251,6 +263,32 @@ describe("Agent tool schema — stealth", () => {
 /* ------------------------------------------------------------------ */
 /*  Tool Registration Count                                           */
 /* ------------------------------------------------------------------ */
+
+describe("message renderer registration", () => {
+  let api: MockExtensionAPI;
+
+  beforeAll(async () => {
+    api = createMockExtensionAPI();
+    await loadExtension(api.api);
+  });
+
+  beforeEach(() => {
+    mutableStore.agent.hideBackgroundCompletionsWhenCompact = false;
+  });
+
+  it("registers the subagent-result renderer", () => {
+    expect(api.messageRenderers.map((r) => r.customType)).toContain("subagent-result");
+  });
+
+  it("uses the persisted setting and renderer expanded state", () => {
+    const renderer = api.messageRenderers.find((r) => r.customType === "subagent-result")!.renderer;
+    const theme = { fg: (_color: string, text: string) => text, bg: (_color: string, text: string) => text };
+
+    mutableStore.agent.hideBackgroundCompletionsWhenCompact = true;
+    expect(renderer({ content: "done" }, { expanded: false }, theme).children).toHaveLength(0);
+    expect(renderer({ content: "done" }, { expanded: true }, theme).children.length).toBeGreaterThan(0);
+  });
+});
 
 describe("tool registration", () => {
   let api: MockExtensionAPI;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -141,7 +141,7 @@ const { mutableStore, spawnGuard } = vi.hoisted(() => ({
       forceBackground: false,
       showCost: false,
       agentToolStrictMode: false,
-      hideBackgroundCompletions: false,
+      showCompletionCards: true,
     },
     modelFor: () => "anthropic/claude-sonnet-4-6",
   },
@@ -258,7 +258,7 @@ describe("message renderer registration", () => {
   });
 
   beforeEach(() => {
-    mutableStore.agent.hideBackgroundCompletions = false;
+    mutableStore.agent.showCompletionCards = true;
   });
 
   it("registers the subagent-result renderer", () => {
@@ -269,7 +269,7 @@ describe("message renderer registration", () => {
     const renderer = api.messageRenderers.find((r) => r.customType === "subagent-result")!.renderer;
     const theme = { fg: (_color: string, text: string) => text, bg: (_color: string, text: string) => text };
 
-    mutableStore.agent.hideBackgroundCompletions = true;
+    mutableStore.agent.showCompletionCards = false;
     expect(renderer({ content: "done" }, { expanded: false }, theme).children).toHaveLength(0);
     expect(renderer({ content: "done" }, { expanded: true }, theme).children).toHaveLength(0);
   });

--- a/test/menu-mock-setup.ts
+++ b/test/menu-mock-setup.ts
@@ -179,7 +179,7 @@ vi.mock("../src/shell.js", async () => {
         widgetMaxLines,
         widgetMaxLinesCompact: a.widgetMaxLinesCompact ?? Math.floor(widgetMaxLines / 2),
         widgetCompact: a.widgetCompact === true,
-        hideBackgroundCompletions: a.hideBackgroundCompletions === true,
+        showCompletionCards: a.showCompletionCards !== false,
         widgetShortcut: a.widgetShortcut === true,
         widgetDescLengthFull: a.widgetDescLengthFull ?? DEFAULT_AGENT.widgetDescLengthFull,
         widgetDescLengthCompact: a.widgetDescLengthCompact ?? DEFAULT_AGENT.widgetDescLengthCompact,
@@ -267,7 +267,7 @@ vi.mock("../src/shell.js", async () => {
             "widgetDescLengthFull",
             "widgetDescLengthCompact",
             "widgetCompact",
-            "hideBackgroundCompletions",
+            "showCompletionCards",
             "widgetShortcut",
             "systemPromptMode",
             "includeContextFiles",
@@ -352,8 +352,8 @@ vi.mock("../src/shell.js", async () => {
         setCompact(enabled: boolean) {
           mockModules.mockConfig.agent.widgetCompact = enabled;
         },
-        setHideBackgroundCompletions(enabled: boolean) {
-          mockModules.mockConfig.agent.hideBackgroundCompletions = enabled;
+        setShowCompletionCards(enabled: boolean) {
+          mockModules.mockConfig.agent.showCompletionCards = enabled;
         },
         setMaxLines(lines: number) {
           mockModules.mockConfig.agent.widgetMaxLines = lines;

--- a/test/menu-mock-setup.ts
+++ b/test/menu-mock-setup.ts
@@ -172,6 +172,7 @@ vi.mock("../src/shell.js", () => {
         widgetMaxLines,
         widgetMaxLinesCompact: a.widgetMaxLinesCompact ?? Math.floor(widgetMaxLines / 2),
         widgetCompact: a.widgetCompact === true,
+        hideBackgroundCompletionsWhenCompact: a.hideBackgroundCompletionsWhenCompact === true,
         widgetShortcut: a.widgetShortcut === true,
         widgetDescLengthFull: a.widgetDescLengthFull ?? 50,
         widgetDescLengthCompact: a.widgetDescLengthCompact ?? 30,
@@ -259,6 +260,7 @@ vi.mock("../src/shell.js", () => {
             "widgetDescLengthFull",
             "widgetDescLengthCompact",
             "widgetCompact",
+            "hideBackgroundCompletionsWhenCompact",
             "widgetShortcut",
             "systemPromptMode",
             "includeContextFiles",
@@ -342,6 +344,9 @@ vi.mock("../src/shell.js", () => {
       widget: {
         setCompact(enabled: boolean) {
           mockModules.mockConfig.agent.widgetCompact = enabled;
+        },
+        setHideBackgroundCompletionsWhenCompact(enabled: boolean) {
+          mockModules.mockConfig.agent.hideBackgroundCompletionsWhenCompact = enabled;
         },
         setMaxLines(lines: number) {
           mockModules.mockConfig.agent.widgetMaxLines = lines;

--- a/test/menu-mock-setup.ts
+++ b/test/menu-mock-setup.ts
@@ -172,7 +172,7 @@ vi.mock("../src/shell.js", () => {
         widgetMaxLines,
         widgetMaxLinesCompact: a.widgetMaxLinesCompact ?? Math.floor(widgetMaxLines / 2),
         widgetCompact: a.widgetCompact === true,
-        hideBackgroundCompletionsWhenCompact: a.hideBackgroundCompletionsWhenCompact === true,
+        hideBackgroundCompletions: a.hideBackgroundCompletions === true,
         widgetShortcut: a.widgetShortcut === true,
         widgetDescLengthFull: a.widgetDescLengthFull ?? 50,
         widgetDescLengthCompact: a.widgetDescLengthCompact ?? 30,
@@ -260,7 +260,7 @@ vi.mock("../src/shell.js", () => {
             "widgetDescLengthFull",
             "widgetDescLengthCompact",
             "widgetCompact",
-            "hideBackgroundCompletionsWhenCompact",
+            "hideBackgroundCompletions",
             "widgetShortcut",
             "systemPromptMode",
             "includeContextFiles",
@@ -345,8 +345,8 @@ vi.mock("../src/shell.js", () => {
         setCompact(enabled: boolean) {
           mockModules.mockConfig.agent.widgetCompact = enabled;
         },
-        setHideBackgroundCompletionsWhenCompact(enabled: boolean) {
-          mockModules.mockConfig.agent.hideBackgroundCompletionsWhenCompact = enabled;
+        setHideBackgroundCompletions(enabled: boolean) {
+          mockModules.mockConfig.agent.hideBackgroundCompletions = enabled;
         },
         setMaxLines(lines: number) {
           mockModules.mockConfig.agent.widgetMaxLines = lines;

--- a/test/ui/menu/menu-widget-settings.test.ts
+++ b/test/ui/menu/menu-widget-settings.test.ts
@@ -76,7 +76,7 @@ function setupMockConfig() {
     widgetMaxLines: 12,
     widgetMaxLinesCompact: 6,
     widgetCompact: false,
-    hideBackgroundCompletions: false,
+    showCompletionCards: true,
     widgetShortcut: false,
     widgetDescLengthFull: 50,
     widgetDescLengthCompact: 30,
@@ -330,12 +330,12 @@ describe("showWidgetSettingsMenu — Behavior submenu", () => {
       "finishedEvictTurns",
       "__sep__",
       "shortcut",
-      "hideBackgroundCompletions",
+      "showCompletionCards",
       "thinkingBuffer",
     ]);
 
-    const item = settingsListCalls[0].items.find((i: any) => i.id === "hideBackgroundCompletions");
-    expect(item.label).toBe("Hide background completions");
+    const item = settingsListCalls[0].items.find((i: any) => i.id === "showCompletionCards");
+    expect(item.label).toBe("Show completion cards");
     expect(typeof item.description).toBe("string");
   });
 
@@ -350,8 +350,8 @@ describe("showWidgetSettingsMenu — Behavior submenu", () => {
   it("completion visibility onChange toggles store and refreshes chat cards", async () => {
     const ctx = createDispatchCtx("behavior");
     await showWidgetSettingsMenu(ctx);
-    settingsListCalls[0].onChange("hideBackgroundCompletions", "ON");
-    expect(mockModules.mockConfig.agent.hideBackgroundCompletions).toBe(true);
+    settingsListCalls[0].onChange("showCompletionCards", "OFF");
+    expect(mockModules.mockConfig.agent.showCompletionCards).toBe(false);
     // Cards already in the transcript only re-render when the host rebuilds them,
     // so the toggle must request a chat refresh...
     expect(ctx.ui.setToolsExpanded).toHaveBeenCalled();

--- a/test/ui/menu/menu-widget-settings.test.ts
+++ b/test/ui/menu/menu-widget-settings.test.ts
@@ -103,6 +103,9 @@ function setupMockConfig() {
 /** Create a ctx that dispatches a specific category choice on first custom call. */
 function createDispatchCtx(choice: string) {
   let callCount = 0;
+  // Stateful: setToolsExpanded updates the value getToolsExpanded reads, so the
+  // test can assert the refresh restores the original expansion state.
+  let toolExpanded = false;
   return {
     ui: {
       custom: vi.fn(async (factory: any) => {
@@ -121,6 +124,10 @@ function createDispatchCtx(choice: string) {
         return undefined;
       }),
       notify: vi.fn(),
+      getToolsExpanded: vi.fn(() => toolExpanded),
+      setToolsExpanded: vi.fn((expanded: boolean) => {
+        toolExpanded = expanded;
+      }),
     },
     modelRegistry: { getAvailable: vi.fn(() => []) },
   };
@@ -340,11 +347,16 @@ describe("showWidgetSettingsMenu — Behavior submenu", () => {
     expect(mockModules.mockConfig.agent.widgetShortcut).toBe(true);
   });
 
-  it("completion visibility onChange toggles store", async () => {
+  it("completion visibility onChange toggles store and refreshes chat cards", async () => {
     const ctx = createDispatchCtx("behavior");
     await showWidgetSettingsMenu(ctx);
     settingsListCalls[0].onChange("hideBackgroundCompletions", "ON");
     expect(mockModules.mockConfig.agent.hideBackgroundCompletions).toBe(true);
+    // Cards already in the transcript only re-render when the host rebuilds them,
+    // so the toggle must request a chat refresh...
+    expect(ctx.ui.setToolsExpanded).toHaveBeenCalled();
+    // ...and the refresh must leave the user's tool-output expansion state untouched.
+    expect(ctx.ui.getToolsExpanded()).toBe(false);
   });
 
   it("thinkingBuffer onChange updates numeric value", async () => {

--- a/test/ui/menu/menu-widget-settings.test.ts
+++ b/test/ui/menu/menu-widget-settings.test.ts
@@ -76,6 +76,7 @@ function setupMockConfig() {
     widgetMaxLines: 12,
     widgetMaxLinesCompact: 6,
     widgetCompact: false,
+    hideBackgroundCompletionsWhenCompact: false,
     widgetShortcut: false,
     widgetDescLengthFull: 50,
     widgetDescLengthCompact: 30,
@@ -319,11 +320,23 @@ describe("showWidgetSettingsMenu — Behavior submenu", () => {
     (getAgentConfig as any).mockImplementation(() => undefined);
   });
 
-  it("dispatches to Behavior SettingsList with 5 items", async () => {
+  it("dispatches to Behavior SettingsList with completion visibility", async () => {
     const ctx = createDispatchCtx("behavior");
     await showWidgetSettingsMenu(ctx);
     const ids = settingsListCalls[0].items.map((i: any) => i.id);
-    expect(ids).toEqual(["finishedRetention", "finishedEvictTurns", "__sep__", "shortcut", "thinkingBuffer"]);
+    expect(ids).toEqual([
+      "finishedRetention",
+      "finishedEvictTurns",
+      "__sep__",
+      "shortcut",
+      "hideBackgroundCompletionsWhenCompact",
+      "thinkingBuffer",
+    ]);
+
+    const item = settingsListCalls[0].items.find((i: any) => i.id === "hideBackgroundCompletionsWhenCompact");
+    expect(item.label).toBe("Hide background completions when compact");
+    expect(item.currentValue).toBe("OFF");
+    expect(item.description).toContain("Results remain available to the model and Running agents");
   });
 
   it("shortcut onChange toggles store", async () => {
@@ -332,6 +345,13 @@ describe("showWidgetSettingsMenu — Behavior submenu", () => {
     await showWidgetSettingsMenu(ctx);
     settingsListCalls[0].onChange("shortcut", "ON");
     expect(mockModules.mockConfig.agent.widgetShortcut).toBe(true);
+  });
+
+  it("completion visibility onChange toggles store", async () => {
+    const ctx = createDispatchCtx("behavior");
+    await showWidgetSettingsMenu(ctx);
+    settingsListCalls[0].onChange("hideBackgroundCompletionsWhenCompact", "ON");
+    expect(mockModules.mockConfig.agent.hideBackgroundCompletionsWhenCompact).toBe(true);
   });
 
   it("thinkingBuffer onChange updates numeric value", async () => {

--- a/test/ui/menu/menu-widget-settings.test.ts
+++ b/test/ui/menu/menu-widget-settings.test.ts
@@ -76,7 +76,7 @@ function setupMockConfig() {
     widgetMaxLines: 12,
     widgetMaxLinesCompact: 6,
     widgetCompact: false,
-    hideBackgroundCompletionsWhenCompact: false,
+    hideBackgroundCompletions: false,
     widgetShortcut: false,
     widgetDescLengthFull: 50,
     widgetDescLengthCompact: 30,
@@ -329,12 +329,12 @@ describe("showWidgetSettingsMenu — Behavior submenu", () => {
       "finishedEvictTurns",
       "__sep__",
       "shortcut",
-      "hideBackgroundCompletionsWhenCompact",
+      "hideBackgroundCompletions",
       "thinkingBuffer",
     ]);
 
-    const item = settingsListCalls[0].items.find((i: any) => i.id === "hideBackgroundCompletionsWhenCompact");
-    expect(item.label).toBe("Hide background completions when compact");
+    const item = settingsListCalls[0].items.find((i: any) => i.id === "hideBackgroundCompletions");
+    expect(item.label).toBe("Hide background completions");
     expect(item.currentValue).toBe("OFF");
     expect(item.description).toContain("Results remain available to the model and Running agents");
   });
@@ -350,8 +350,8 @@ describe("showWidgetSettingsMenu — Behavior submenu", () => {
   it("completion visibility onChange toggles store", async () => {
     const ctx = createDispatchCtx("behavior");
     await showWidgetSettingsMenu(ctx);
-    settingsListCalls[0].onChange("hideBackgroundCompletionsWhenCompact", "ON");
-    expect(mockModules.mockConfig.agent.hideBackgroundCompletionsWhenCompact).toBe(true);
+    settingsListCalls[0].onChange("hideBackgroundCompletions", "ON");
+    expect(mockModules.mockConfig.agent.hideBackgroundCompletions).toBe(true);
   });
 
   it("thinkingBuffer onChange updates numeric value", async () => {

--- a/test/ui/menu/menu-widget-settings.test.ts
+++ b/test/ui/menu/menu-widget-settings.test.ts
@@ -329,8 +329,7 @@ describe("showWidgetSettingsMenu — Behavior submenu", () => {
 
     const item = settingsListCalls[0].items.find((i: any) => i.id === "hideBackgroundCompletions");
     expect(item.label).toBe("Hide background completions");
-    expect(item.currentValue).toBe("OFF");
-    expect(item.description).toContain("Results remain available to the model and Running agents");
+    expect(typeof item.description).toBe("string");
   });
 
   it("shortcut onChange toggles store", async () => {

--- a/test/ui/renderer.test.ts
+++ b/test/ui/renderer.test.ts
@@ -1,13 +1,3 @@
-/**
- * worktree-renderer.test.ts — Tests for worktree path display in the details pane.
- *
- * Verifies:
- *   - renderSubagentResult includes worktree: path in the result card
- *   - buildFallbackResultLine (via renderSubagentResult without turnCount) includes worktree: path
- *
- * Note: renderer.ts no longer imports shell.ts — showCost is passed as a parameter.
- */
-
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 /* ------------------------------------------------------------------ */

--- a/test/ui/renderer.test.ts
+++ b/test/ui/renderer.test.ts
@@ -72,30 +72,26 @@ const SHOW_COST = false;
 /*  Tests                                                             */
 /* ------------------------------------------------------------------ */
 
-describe("renderSubagentResult — compact completion visibility", () => {
+describe("renderSubagentResult — completion visibility", () => {
   beforeEach(() => {
     textInstances.length = 0;
   });
 
-  it("renders by default while collapsed", () => {
+  it("renders by default", () => {
     const result = renderSubagentResult({ content: "Result" }, { expanded: false }, noopTheme, SHOW_COST);
 
     expect(result.children).not.toHaveLength(0);
   });
 
-  it.each([{ expanded: false }, {}])("returns an empty component when enabled and not expanded (%j)", (options) => {
-    const result = renderSubagentResult({ content: "Result" }, options, noopTheme, SHOW_COST, "id", true);
+  it.each([{ expanded: false }, { expanded: true }, {}])(
+    "returns an empty component when hiding is enabled (%j)",
+    (options) => {
+      const result = renderSubagentResult({ content: "Result" }, options, noopTheme, SHOW_COST, "id", true);
 
-    expect(result.children).toHaveLength(0);
-    expect(textInstances).toHaveLength(0);
-  });
-
-  it("renders when enabled and expanded", () => {
-    const result = renderSubagentResult({ content: "Result" }, { expanded: true }, noopTheme, SHOW_COST, "id", true);
-
-    expect(result.children).not.toHaveLength(0);
-    expect(textInstances.length).toBeGreaterThan(0);
-  });
+      expect(result.children).toHaveLength(0);
+      expect(textInstances).toHaveLength(0);
+    },
+  );
 });
 
 describe("renderSubagentResult — worktree path display", () => {

--- a/test/ui/renderer.test.ts
+++ b/test/ui/renderer.test.ts
@@ -72,6 +72,32 @@ const SHOW_COST = false;
 /*  Tests                                                             */
 /* ------------------------------------------------------------------ */
 
+describe("renderSubagentResult — compact completion visibility", () => {
+  beforeEach(() => {
+    textInstances.length = 0;
+  });
+
+  it("renders by default while collapsed", () => {
+    const result = renderSubagentResult({ content: "Result" }, { expanded: false }, noopTheme, SHOW_COST);
+
+    expect(result.children).not.toHaveLength(0);
+  });
+
+  it.each([{ expanded: false }, {}])("returns an empty component when enabled and not expanded (%j)", (options) => {
+    const result = renderSubagentResult({ content: "Result" }, options, noopTheme, SHOW_COST, "id", true);
+
+    expect(result.children).toHaveLength(0);
+    expect(textInstances).toHaveLength(0);
+  });
+
+  it("renders when enabled and expanded", () => {
+    const result = renderSubagentResult({ content: "Result" }, { expanded: true }, noopTheme, SHOW_COST, "id", true);
+
+    expect(result.children).not.toHaveLength(0);
+    expect(textInstances.length).toBeGreaterThan(0);
+  });
+});
+
 describe("renderSubagentResult — worktree path display", () => {
   beforeEach(() => {
     textInstances.length = 0;


### PR DESCRIPTION
Hey, first of all, thank you for this extension, it's a hidden gem. The small context load, the easy of use, fantastic. Everything I though i might want to look or behave differently turned out to be configurable.. Except this one thing.. I'd like to hide the background completion card. Let me know if you'd prefer for this to be implemented differently, i'll gladly change it to get this functionality merged.

## Summary
- add a persisted, default-off Widget settings → Behavior toggle
- hide `subagent-result` completion cards whenever the setting is enabled, independent of renderer expansion state
- preserve model delivery and Running agents access, with docs and changelog updates

## Tests
- `bun run typecheck`
- `bun run test` (1154 passed)
- `bun run format:check`
