### PR TITLE
fix: recognize ls as a built-in tool

### DIFF
--- a/src/agents/agent-types.ts
+++ b/src/agents/agent-types.ts
@@ -10,14 +10,14 @@ import { DEFAULT_AGENTS } from "./default-agents.js";
 import type { AgentConfig } from "./types.js";
 
 /**
- * All tool names that Pi can provide to a session.
+ * All Pi built-in tool names. This registry must contain every Pi built-in so
+ * validation does not misclassify one as an extension tool. `ls` is a Pi
+ * built-in explicitly activated for restricted sessions.
  *
  * Note: only `read`, `bash`, `edit`, `write` are active by default.
  * `find` and `grep` must be explicitly activated via setActiveToolsByName().
- * `ls` was removed — it's a thin wrapper over bash that adds ~180 tokens/turn
- * with no real benefit.
  */
-export const BUILTIN_TOOL_NAMES: string[] = ["read", "bash", "edit", "write", "grep", "find"];
+export const BUILTIN_TOOL_NAMES: string[] = ["read", "bash", "edit", "write", "grep", "find", "ls"];
 
 /** Unified runtime registry of all agents (defaults + user-defined). */
 const agents = new Map<string, AgentConfig>();

--- a/test/agents/agent-types-resolver.test.ts
+++ b/test/agents/agent-types-resolver.test.ts
@@ -116,6 +116,20 @@ describe("resolveVisibleTools — allowlist mode", () => {
     expect(result).not.toContain("bash");
   });
 
+  it("allows ls in a restricted session without an unknown-tool warning", () => {
+    const notify = vi.fn();
+
+    const result = resolveVisibleTools({
+      activeTools: ["ls"],
+      tools: ["ls"],
+      extToolMap: new Map(),
+      notify,
+    });
+
+    expect(result).toEqual(["ls"]);
+    expect(notify).not.toHaveBeenCalled();
+  });
+
   it("warns about unknown bare tool name not in builtins or extensions", () => {
     const notify = vi.fn();
 


### PR DESCRIPTION
## Summary

Agent frontmatter with a restricted `tools: ["ls"]` allowlist currently emits `tool "ls" not found in any loaded extension`.

`resolveVisibleTools` validates bare names against `BUILTIN_TOOL_NAMES`, but `ls` is a Pi built-in explicitly activated for restricted sessions and was missing from that registry. Add `ls` and document that the registry must include every Pi built-in to avoid extension-tool misclassification.

## Tests

- `bun test test/agents/agent-types-resolver.test.ts`
- `bun run typecheck`