### PR TITLE
fix(utils): guard parseModelKey against non-string input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`parseModelKey` is now total.** A malformed config value (object, number, null) reaching `parseModelKey` no longer crashes `pi` with `TypeError: modelStr.indexOf is not a function`. The parameter is widened to `unknown` and a `typeof` guard returns `null` for non-strings, rendering "(inherits parent)" instead of exiting. Backstop for the Model Settings menu crash described in `PI_SUBAGENT_LITE_BUG.md`.
 
+### Changed
+
+- **Malformed model overrides are dropped at load with a warning.** A non-string, non-null value for `agent.default` or a per-type override key in `subagents-lite.json` (e.g. `"default": 42` or `"general-purpose": { ... }`) is now deleted at load time and reported via a `[subagents] Ignoring malformed model override…` `console.warn`, rather than silently propagating to the Model Settings menu. Validation lives at the load boundary (`readGlobalRaw`/`readProjectRaw`), so it fires once on init/reload — not on every config mutation — and `parseModelKey`'s `unknown` guard remains as a pure backstop.
+
 ## [1.13.0] - 2026-08-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`parseModelKey` is now total.** A malformed config value (object, number, null) reaching `parseModelKey` no longer crashes `pi` with `TypeError: modelStr.indexOf is not a function`. The parameter is widened to `unknown` and a `typeof` guard returns `null` for non-strings, rendering "(inherits parent)" instead of exiting. Backstop for the Model Settings menu crash described in `PI_SUBAGENT_LITE_BUG.md`.
+
 ## [1.13.0] - 2026-08-20
 
 ### Added

--- a/src/config/config-io.ts
+++ b/src/config/config-io.ts
@@ -244,13 +244,39 @@ export function mergeDefaults(raw: RawConfig): SubagentsConfig {
 
 // ── Load ─────────────────────────────────────────────────────────────
 
+/** Drop malformed model-override values from a raw agent layer and warn.
+ *  `default` and per-type override keys (any key not in
+ *  CONFIG_AGENT_NON_MODEL_KEYS) must be string|null; a non-string, non-null
+ *  value is deleted so it falls back to the baked default / next chain layer
+ *  instead of crashing parseModelKey downstream. Non-model keys are untouched. */
+function dropMalformedModelOverrides(rawAgent: Record<string, unknown>): void {
+  const def = rawAgent.default;
+  if (def != null && typeof def !== "string") {
+    console.warn(
+      `[subagents] Ignoring malformed model override in config: agent.default expected "provider/model-id" string, got ${typeof def} (${JSON.stringify(def)}).`,
+    );
+    delete rawAgent.default;
+  }
+  for (const [key, value] of Object.entries(rawAgent)) {
+    if (CONFIG_AGENT_NON_MODEL_KEYS.includes(key)) continue;
+    if (value == null || typeof value === "string") continue;
+    console.warn(
+      `[subagents] Ignoring malformed model override in config: agent.${key} expected "provider/model-id" string, got ${typeof value} (${JSON.stringify(value)}).`,
+    );
+    delete rawAgent[key];
+  }
+}
+
 /** Read the global file; any failure (missing, malformed) reads as {} — as today. */
 function readGlobalRaw(): RawConfig {
+  let raw: RawConfig;
   try {
-    return JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8")) as RawConfig;
+    raw = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8")) as RawConfig;
   } catch {
     return {};
   }
+  if (raw.agent) dropMalformedModelOverrides(raw.agent);
+  return raw;
 }
 
 /** Read the project file; missing = absent, unreadable/invalid = malformed + warning. */
@@ -279,6 +305,7 @@ function readProjectRaw(projectPath: string): ProjectRead {
     return malformedSection(projectPath, "concurrency.models");
   }
   const unknownKeys = Object.keys(raw.agent ?? {}).filter((key) => !isProjectAllowedAgentKey(key));
+  if (raw.agent) dropMalformedModelOverrides(raw.agent);
   return { raw, unknownKeys };
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -58,8 +58,9 @@ export function errorMessage(err: unknown): string {
   return toSingleLine(err instanceof Error ? err.message : String(err));
 }
 
-/** Parse "provider/model-id" into { provider, modelId }; null if invalid (no slash or empty provider). */
-export function parseModelKey(modelStr: string): { provider: string; modelId: string } | null {
+/** Parse "provider/model-id" into { provider, modelId }; null if invalid (no slash, empty provider, or a non-string argument). */
+export function parseModelKey(modelStr: unknown): { provider: string; modelId: string } | null {
+  if (typeof modelStr !== "string") return null;
   const slashIdx = modelStr.indexOf("/");
   if (slashIdx <= 0) return null;
   return { provider: modelStr.slice(0, slashIdx), modelId: modelStr.slice(slashIdx + 1) };

--- a/test/config/config-io-project-file.test.ts
+++ b/test/config/config-io-project-file.test.ts
@@ -4,7 +4,7 @@
  * file; absent keys inherit. Unknown keys are ignored with a warning, a
  * malformed file is never written, and per-layer saves touch only their layer.
  */
-import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach, afterAll, type Mock } from "vitest";
 import { join } from "node:path";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -250,6 +250,98 @@ describe("mergeDefaults / loadConfig", () => {
 
     expect(loadConfig()).toEqual(
       mergeDefaults({ agent: { default: "g", graceTurns: 5 }, concurrency: { default: 2 } }),
+    );
+  });
+});
+
+describe("malformed model overrides — drop + warn at load", () => {
+  let warn: Mock;
+  beforeEach(() => {
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it("drops a non-string global default and warns, falling back to null", () => {
+    writeGlobal({ agent: { default: 42 }, concurrency: { default: 2 } });
+
+    const config = loadConfig();
+
+    expect(config.agent.default).toBeNull();
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('agent.default expected "provider/model-id" string, got number (42)'),
+    );
+  });
+
+  it("drops an object global default and warns", () => {
+    writeGlobal({ agent: { default: { model: "x" } } });
+
+    expect(loadConfig().agent.default).toBeNull();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("got object"));
+  });
+
+  it("drops a non-string per-type override and warns", () => {
+    writeGlobal({ agent: { "general-purpose": 99 } });
+
+    const config = loadConfig();
+
+    expect(config.agent["general-purpose"]).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('agent.general-purpose expected "provider/model-id" string, got number (99)'),
+    );
+  });
+
+  it("keeps valid model overrides and emits no warning", () => {
+    writeGlobal({ agent: { default: "anthropic/claude", "general-purpose": "openai/gpt" } });
+
+    const config = loadConfig();
+
+    expect(config.agent.default).toBe("anthropic/claude");
+    expect(config.agent["general-purpose"]).toBe("openai/gpt");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("keeps null and empty-string model overrides (valid unset) without warning", () => {
+    writeGlobal({ agent: { default: null, "general-purpose": "" } });
+
+    const config = loadConfig();
+
+    expect(config.agent.default).toBeNull();
+    expect(config.agent["general-purpose"]).toBe("");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("does not touch non-model keys (number/boolean values are legitimate)", () => {
+    writeGlobal({ agent: { graceTurns: 7, forceBackground: true } });
+
+    const config = loadConfig();
+
+    expect(config.agent.graceTurns).toBe(7);
+    expect(config.agent.forceBackground).toBe(true);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("drops a non-string project default at io.load and warns", () => {
+    writeProject({ agent: { default: 7 } });
+
+    const loaded = createConfigIO(projectDir).load();
+
+    expect(loaded.project?.agent?.default).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('agent.default expected "provider/model-id" string, got number (7)'),
+    );
+  });
+
+  it("drops a non-string project per-type override at io.load and warns", () => {
+    writeProject({ agent: { explore: [1, 2] } });
+
+    const loaded = createConfigIO(projectDir).load();
+
+    expect(loaded.project?.agent?.["explore"]).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('agent.explore expected "provider/model-id" string, got object'),
     );
   });
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -186,6 +186,13 @@ describe("parseModelKey", () => {
     expect(parseModelKey("no-slash")).toBeNull();
     expect(parseModelKey("/leading-slash")).toBeNull();
   });
+
+  it("returns null for non-string arguments (malformed config backstop)", () => {
+    expect(parseModelKey(null)).toBeNull();
+    expect(parseModelKey(undefined)).toBeNull();
+    expect(parseModelKey({ model: "x" } as unknown as string)).toBeNull();
+    expect(parseModelKey(42 as unknown as string)).toBeNull();
+  });
 });
 
 describe("findModelInRegistry", () => {


### PR DESCRIPTION
https://github.com/AlexParamonov/pi-subagents-lite/issues/19  

**1st** commit Just hides the fact that user has bad config value
**2nd** commit May be a more proper fix

Let me know if you want to drop or modify the second commit or if it is good