### PR TITLE
fix(ui): use portable tool count glyph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Tool count marker renders reliably across terminal fonts.** Replaced the forced text-presentation emoji with a one-cell text symbol, avoiding the Unicode replacement glyph when that text variant is unavailable.
+
 ## [1.13.0] - 2026-08-20
 
 ### Added

--- a/src/ui/format.ts
+++ b/src/ui/format.ts
@@ -152,7 +152,7 @@ export function buildStatsParts(
   visible?: StatsVisibility,
 ): string[] {
   const parts: string[] = [];
-  if (visible?.showTools !== false && args.toolUses > 0) parts.push(`${args.toolUses}🛠︎ `);
+  if (visible?.showTools !== false && args.toolUses > 0) parts.push(`${args.toolUses}⚒ `);
   if (visible?.showTurns !== false && args.turnCount != null)
     parts.push(formatTurns(args.turnCount, args.maxTurns, theme));
   if (visible?.showInput !== false || visible?.showOutput !== false) {

--- a/src/ui/menu/menu-widget-settings.ts
+++ b/src/ui/menu/menu-widget-settings.ts
@@ -27,7 +27,7 @@ function buildStatConfig(store: ReturnType<typeof getStore>): Map<string, StatTo
       "showTools",
       {
         label: "Tools",
-        description: "Show tool count 🛠︎  in the widget.",
+        description: "Show tool count ⚒  in the widget.",
         get: () => store.agent.showTools,
         set: (v) => store.mutate.agent.setShowTools(v),
       },

--- a/test/ui/agent-widget.test.ts
+++ b/test/ui/agent-widget.test.ts
@@ -556,7 +556,7 @@ describe("stats visibility integration", () => {
 
     const lines = renderWidgetLines(widget);
     const allText = lines.join(" ");
-    expect(allText).not.toContain("🛠︎");
+    expect(allText).not.toContain("⚒");
   });
 
   it("hides time when showTime is false", () => {
@@ -623,7 +623,7 @@ describe("stats visibility integration", () => {
 
     const lines = renderWidgetLines(widget);
     const allText = lines.join(" ");
-    expect(allText).not.toContain("🛠︎");
+    expect(allText).not.toContain("⚒");
   });
 
   it("shows all stats when visibility flags are all true (default)", () => {
@@ -643,7 +643,7 @@ describe("stats visibility integration", () => {
 
     const lines = renderWidgetLines(widget);
     const allText = lines.join(" ");
-    expect(allText).toContain("🛠︎");
+    expect(allText).toContain("⚒");
     expect(allText).toContain("⟳");
     expect(allText).toContain("↑");
     expect(allText).toContain("$");

--- a/test/ui/format.test.ts
+++ b/test/ui/format.test.ts
@@ -58,12 +58,13 @@ const allStats = {
 describe("buildStatsParts — visible flag: showTools", () => {
   it("excludes toolUses when showTools is false", () => {
     const parts = buildStatsParts(allStats, mockTheme, { showTools: false });
-    expect(parts.some((p) => p.includes("🛠︎"))).toBe(false);
+    expect(parts.some((p) => p.includes("⚒"))).toBe(false);
   });
 
-  it("includes toolUses when showTools is true (default)", () => {
+  it("includes the exact tool count marker when showTools is true (default)", () => {
     const parts = buildStatsParts(allStats, mockTheme);
-    expect(parts.some((p) => p.includes("🛠︎"))).toBe(true);
+    expect(parts[0]).toBe("5⚒ ");
+    expect(parts.join("")).not.toContain("\uFE0E");
   });
 });
 


### PR DESCRIPTION
## Why

The tool count marker used `🛠︎` (`U+1F6E0 U+FE0E`). The variation selector forces a text presentation, but some terminal font fallback chains do not provide that variant and render the Unicode replacement glyph instead.

## What changed

- replace the tool count marker with the one-cell text symbol `⚒` (`U+2692`)
- update the widget settings description
- pin the exact marker in formatting and widget tests
- assert that formatting does not emit `U+FE0E`
- document the fix in the changelog

## Verification

- `npm run typecheck`
- `npm run test` (75 files, 1,688 tests passed)
- `npm run format:check`

<img width="752" height="79" alt="image" src="https://github.com/user-attachments/assets/f64e3685-c3a1-4505-8841-305bfb922323" />

